### PR TITLE
Added extra_commit to rangeproof functions.

### DIFF
--- a/include/wally_elements.h
+++ b/include/wally_elements.h
@@ -72,6 +72,8 @@ WALLY_CORE_API int wally_asset_rangeproof(
     size_t commitment_len,
     const unsigned char *generator,
     size_t generator_len,
+    const unsigned char *extra_commit,
+    size_t extra_commit_len,
     unsigned char *bytes_out,
     size_t len,
     size_t *written);
@@ -110,6 +112,8 @@ WALLY_CORE_API int wally_asset_unblind(
     size_t commitment_len,
     const unsigned char *generator,
     size_t generator_len,
+    const unsigned char *extra_commit,
+    size_t extra_commit_len,
     unsigned char *asset_out,
     size_t asset_out_len,
     unsigned char *abf_out,

--- a/src/swig_java/jni_extra.java_in
+++ b/src/swig_java/jni_extra.java_in
@@ -120,9 +120,9 @@
   }
 
   public final static byte[] asset_rangeproof(long jarg1, byte[] jarg2, byte[] jarg3, byte[] jarg4,
-                                              byte[] jarg5, byte[] jarg6, byte[] jarg7, byte[] jarg8) {
+                                              byte[] jarg5, byte[] jarg6, byte[] jarg7, byte[] jarg8, byte[] jarg9) {
       final byte[] buf = new byte[ASSET_RANGEPROOF_MAX_LEN];
-      final int len = asset_rangeproof(jarg1, jarg2, jarg3, jarg4, jarg5, jarg6, jarg7, jarg8, buf);
+      final int len = asset_rangeproof(jarg1, jarg2, jarg3, jarg4, jarg5, jarg6, jarg7, jarg8, jarg9, buf);
       return trimBuffer(buf, len);
   }
 
@@ -135,11 +135,13 @@
 
   public final static long asset_unblind(byte[] pub_key, byte[] priv_key, byte[] proof,
                                          byte[] commitment, byte[] generator,
+                                         byte[] extra_commit,
                                          final java.util.List<byte[]> outputs) {
       // We return asset_out, abf_out, vbf_out in the passed list
       for (int i = 0; i < 3; i++) // asset_out, abf_out, vbf_out
           outputs.add(new byte[ASSET_TAG_LEN]);
       return asset_unblind(pub_key, priv_key, proof, commitment, generator,
+                           extra_commit,
                            outputs.get(0), outputs.get(1), outputs.get(2));
   }
 }

--- a/src/swig_java/swig.i
+++ b/src/swig_java/swig.i
@@ -197,6 +197,7 @@ static jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t len)
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *chain_code, size_t chain_code_len) };
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *commitment, size_t commitment_len) };
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *generator, size_t generator_len) };
+%apply(char *STRING, size_t LENGTH) { (const unsigned char *extra_commit, size_t extra_commit_len) };
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *hash160, size_t hash160_len) };
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *iv, size_t iv_len) };
 %apply(char *STRING, size_t LENGTH) { (const unsigned char *key, size_t key_len) };


### PR DESCRIPTION
The commit adds the extra_commit and extra_commit_len arguments to the rangeproof and unblind functions. The scriptPubKey is passed as extra_commit, and is thus necessary for blinding.

Also changes the min_value from 0 to 1, as 0 is reserved for scriptPubKeys which are provably unspendable. Without this change, blinding fails as well. (This may need to be a flag argument, as it may not be possible to blind unspendable stuff with a hard-coded 1.)

Additionally adds verification on surjection proof, which seems like a good thing to have, although slightly unrelated.