### PR TITLE
Replace redundant NULL check with assertion in bip39_get_word(...)

### DIFF
--- a/src/bip39.c
+++ b/src/bip39.c
@@ -67,7 +67,8 @@ int bip39_get_word(const struct words *w, size_t idx,
     if (!output || !(word = wordlist_lookup_index(w, idx)))
         return WALLY_EINVAL;
 
-    *output = word ? wally_strdup(word) : NULL;
+    assert(word);
+    *output = wally_strdup(word);
     return *output ? WALLY_OK : WALLY_ENOMEM;
 }
 


### PR DESCRIPTION
Replace redundant `NULL` check with assertion in `bip39_get_word(...)`.