### PR TITLE
Fix the js wrappers debug build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,8 +80,9 @@ cordova-wrappers: $(cordova_wrap_files)
 
 if USE_JS_WRAPPERS
 # The node wrapper is built by node-gyp
+NODE_GYP = node_modules/.bin/node-gyp
 wrap_js/build/@NODE_GYP_DIR@/wallycore.node: wrap_js/nodejs_wrap.cc wrap_js/wally.js $(lib_LTLIBRARIES)
-	cd wrap_js && LIBWALLY_DIR=../.. NODE_GYP_DIR=@NODE_GYP_DIR@ yarn install
+	cd wrap_js && LIBWALLY_DIR=../.. NODE_GYP_DIR=@NODE_GYP_DIR@ $(NODE_GYP) configure @NODE_GYP_FLAGS@ && $(NODE_GYP) build @NODE_GYP_FLAGS@
 
 bin_PROGRAMS = wrap_js/build/@NODE_GYP_DIR@/wallycore.node
 


### PR DESCRIPTION
It's necessary to invoke node-gyp directly in order to pass the --debug
flag. I don't see any way of passing it via yarn install.