### PR TITLE
Update docker images, ndk and minor cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ linux_py3_debug:
     - PYTHON_VERSION=3.5 DEBUG_WALLY=--enable-debug ./tools/travis_build.sh
 
 ubuntu_release:
-  image: greenaddress/wallycore@sha256:98530ad68264c6b50fe2ea060c275ddb2500fc459bded4df16263b464870a3e5
+  image: greenaddress/wallycore@sha256:0cfdaf0b1f62981e3da321da003d09fe9e1fd6f0b052e64121031ff3b5263ad8
   artifacts:
     expire_in: 1 day
     name: wallycore-bindings

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 linux_release:
-  image: greenaddress/wallycore@sha256:a655db9e9b378ab64e0fca9016bd29a21baf40b95fc6f7125247b55394decdc7
+  image: greenaddress/wallycore@sha256:1bda1bb381d7edc25c063fe63c46c0f9e15cc202257640f998a728ec5f43cd4c
   artifacts:
     expire_in: 1 day
     name: wallycore-bindings
@@ -19,7 +19,7 @@ linux_release:
     - gzip -9 wally_dist/wallycore-android-jni.tar
 
 linux_py2_debug:
-  image: greenaddress/wallycore@sha256:a655db9e9b378ab64e0fca9016bd29a21baf40b95fc6f7125247b55394decdc7
+  image: greenaddress/wallycore@sha256:1bda1bb381d7edc25c063fe63c46c0f9e15cc202257640f998a728ec5f43cd4c
   tags:
     - ga
   script:
@@ -29,7 +29,7 @@ linux_py2_debug:
     - DEBUG_WALLY=--enable-debug ./tools/build_js_bindings.sh
 
 linux_py3_debug:
-  image: greenaddress/wallycore@sha256:a655db9e9b378ab64e0fca9016bd29a21baf40b95fc6f7125247b55394decdc7
+  image: greenaddress/wallycore@sha256:1bda1bb381d7edc25c063fe63c46c0f9e15cc202257640f998a728ec5f43cd4c
   tags:
     - ga
   script:
@@ -124,7 +124,7 @@ windows10_release:
     - tools\msvc\wheel.bat
 
 apidocs:
-  image: greenaddress/wallycore@sha256:a655db9e9b378ab64e0fca9016bd29a21baf40b95fc6f7125247b55394decdc7
+  image: greenaddress/wallycore@sha256:1bda1bb381d7edc25c063fe63c46c0f9e15cc202257640f998a728ec5f43cd4c
   artifacts:
     expire_in: 14 days
     name: wallycore-apidocs

--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ $ . ./tools/android_helpers.sh
 $ android_get_arch_list
 armeabi-v7a arm64-v8a x86 x86_64
 
-# Optional, uses gcc instead of clang
-$ export WALLY_USE_GCC=1
-
 # Prepare to build
 $ ./tools/cleanup.sh
 $ ./tools/autogen.sh

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ ./tools/cleanup.sh
 $ ./tools/autogen.sh
 
 # See the comments in tools/android_helpers.sh for arguments
-$ android_build_wally armeabi-v7a $PWD/toolchain-armeabi-v7a 17 "--enable-swig-java"
+$ android_build_wally armeabi-v7a $PWD/toolchain-armeabi-v7a 19 "--enable-swig-java"
 ```
 
 The script `tools/build_android_libraries.sh` builds the Android release files and

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:stretch@sha256:f1f61086ea01a72b30c7287adee8c929e569853de03b7c462a8ac75e0d0224c4
+FROM debian:stretch@sha256:07fe888a6090482fc6e930c1282d1edf67998a39a09a0b339242fbfa2b602fff
 COPY stretch_deps.sh /deps.sh
 RUN /deps.sh && rm /deps.sh
 VOLUME /wallycore
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-ENV ANDROID_NDK=/opt/android-ndk-r17b
+ENV ANDROID_NDK=/opt/android-ndk-r18

--- a/contrib/Dockerfile_ubuntu
+++ b/contrib/Dockerfile_ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04@sha256:c8c275751219dadad8fa56b3ac41ca6cb22219ff117ca98fe82b42f24e1ba64e
+FROM ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
 COPY ubuntu_18.04_deps.sh /deps.sh
 RUN /deps.sh && rm /deps.sh
 VOLUME /wallycore

--- a/contrib/stretch_deps.sh
+++ b/contrib/stretch_deps.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -e
 
-export NDK_FILENAME=android-ndk-r17b-linux-x86_64.zip
+export NDK_FILENAME=android-ndk-r18-linux-x86_64.zip
 
 dpkg --add-architecture i386
 sed -i 's/deb.debian.org/httpredir.debian.org/g' /etc/apt/sources.list

--- a/tools/android_helpers.sh
+++ b/tools/android_helpers.sh
@@ -66,7 +66,7 @@ function android_get_configure_flags() {
     local arch=$1 toolsdir=$2 api=$3
     shift 3
     local useropts=$*
-    local host=$(basename $toolsdir/bin/*-strip | sed 's/-strip$//')
+    local host=$(basename $toolsdir/bin/*linux*-strip | sed 's/-strip$//')
     local args="--host=$host $useropts --enable-endomorph"
     case $arch in
        arm*) args="$args --with-asm=auto";;

--- a/tools/android_helpers.sh
+++ b/tools/android_helpers.sh
@@ -34,11 +34,7 @@ function android_create_toolchain() {
 # api:      The Android API level to build for (e.g. 21)
 function android_get_cflags() {
     local arch=$1 toolsdir=$2 api=$3
-    local cflags=""
-    if [[ -n "$WALLY_USE_GCC" ]]; then
-        cflags="$cflags --sysroot=$toolsdir/sysroot -D__ANDROID_API__=$api"
-    fi
-    cflags="$cflags -isystem $toolsdir/sysroot/usr/include"
+    local cflags="$cflags -isystem $toolsdir/sysroot/usr/include"
     case $arch in
        armeabi-v7a) cflags="$cflags -march=armv7-a -mfloat-abi=softfp -mfpu=neon -mthumb";;
        arm64-v8a) cflags="$cflags -flax-vector-conversions";;
@@ -88,10 +84,7 @@ function android_build_wally() {
     android_create_toolchain $arch $toolsdir $api
 
     # Set cross compilation options for configure
-    # TODO: Support NDK > 14 and clang when they work
-    if [[ -z "$WALLY_USE_GCC" ]]; then
-        export CC="$toolsdir/bin/clang"
-    fi
+    export CC="$toolsdir/bin/clang"
 
     export CFLAGS=$(android_get_cflags $arch $toolsdir $api)
     export LDFLAGS=$(android_get_ldflags $arch $toolsdir $api)

--- a/tools/build_android_libraries.sh
+++ b/tools/build_android_libraries.sh
@@ -25,8 +25,8 @@ if [ -n "$1" ]; then
 fi
 
 for arch in $ARCH_LIST; do
-    # Use API level 14 for non-64 bit targets for better device coverage
-    api="14"
+    # Use API level 19 for non-64 bit targets for better device coverage
+    api="19"
     if [[ $arch == *"64"* ]]; then
         api="21"
     fi

--- a/tools/build_android_libraries.sh
+++ b/tools/build_android_libraries.sh
@@ -42,7 +42,7 @@ for arch in $ARCH_LIST; do
 
     # Copy the build result
     mkdir -p $PWD/release/lib/$arch
-    $toolsdir/bin/*-strip -o $PWD/release/lib/$arch/libwallycore.so $PWD/src/.libs/libwallycore.so
+    $toolsdir/bin/*linux*-strip -o $PWD/release/lib/$arch/libwallycore.so $PWD/src/.libs/libwallycore.so
 done
 
 mkdir -p $PWD/release/include $PWD/release/src/swig_java/src/com/blockstream/libwally


### PR DESCRIPTION
This PR updates the ubuntu and Debian stretch to the latest versions and upgrades to ndk r18

Tested on GreenBits master.