### PR TITLE
Add constant and flag for exact fee estimation with low-r signatures

### DIFF
--- a/include/wally_crypto.h
+++ b/include/wally_crypto.h
@@ -279,6 +279,8 @@ WALLY_CORE_API int wally_pbkdf2_hmac_sha512(
 #define EC_SIGNATURE_LEN 64
 /** The maximum encoded length of a DER encoded signature */
 #define EC_SIGNATURE_DER_MAX_LEN 72
+/** The maximum encoded length of a DER encoded signature created with EC_FLAG_GRIND_R */
+#define EC_SIGNATURE_DER_MAX_LOW_R_LEN 71
 
 /** Indicates that a signature using ECDSA/secp256k1 is required */
 #define EC_FLAG_ECDSA 0x1

--- a/include/wally_script.h
+++ b/include/wally_script.h
@@ -22,9 +22,10 @@ extern "C" {
 #define WALLY_SCRIPTPUBKEY_P2WPKH_LEN 22 /** OP_0 [HASH160] */
 #define WALLY_SCRIPTPUBKEY_P2WSH_LEN  34 /** OP_0 [SHA256] */
 
-#define WALLY_MAX_OP_RETURN_LEN 80
+#define WALLY_SCRIPTPUBKEY_OP_RETURN_MAX_LEN 83 /** OP_RETURN [80 bytes of data] */
 
-#define WALLY_SCRIPTSIG_OP_RETURN_MAX_LEN 83 /** OP_RETURN [80 bytes of data] */
+#define WALLY_MAX_OP_RETURN_LEN 80 /* Maximum length of OP_RETURN data push */
+
 #define WALLY_SCRIPTSIG_P2PKH_MAX_LEN 140 /** [SIG+SIGHASH] [PUBKEY] */
 #define WALLY_WITNESSSCRIPT_MAX_LEN   35 /** (PUSH OF)0 [SHA256] */
 
@@ -252,7 +253,7 @@ WALLY_CORE_API int wally_scriptsig_p2pkh_from_der(
  * :param flags: Currently unused, must be 0.
  * :param bytes_out: Destination for the resulting scriptPubkey.
  * :param len: The length of ``bytes_out`` in bytes. Passing
- *|    ``WALLY_SCRIPTSIG_OP_RETURN_MAX_LEN`` will ensure there is always
+ *|    ``WALLY_SCRIPTPUBKEY_OP_RETURN_MAX_LEN`` will ensure there is always
  *|    enough room for the resulting scriptPubkey.
  * :param written: Destination for the number of bytes written to ``bytes_out``.
  */

--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -25,6 +25,7 @@ extern "C" {
 
 #define WALLY_TX_DUMMY_NULL 0x1 /* An empty witness item */
 #define WALLY_TX_DUMMY_SIG  0x2 /* A dummy signature */
+#define WALLY_TX_DUMMY_SIG_LOW_R  0x4 /* A dummy signature created with EC_FLAG_GRIND_R */
 
 /** Sighash flags for transaction signing */
 #define WALLY_SIGHASH_ALL          0x01

--- a/src/swig_python/python_extra.py_in
+++ b/src/swig_python/python_extra.py_in
@@ -112,7 +112,7 @@ def _spkcsv2of3_2_len_fn(sigs, csv_blocks, flags):
     # TODO: See TODO in _spkcsv2of2_1_len_fn
     return 13 + 3 * (EC_PUBLIC_KEY_LEN + 1) + 4
 scriptpubkey_csv_2of3_then_2_from_bytes = _wrap_bin(scriptpubkey_csv_2of3_then_2_from_bytes, _spkcsv2of3_2_len_fn, resize=True)
-scriptpubkey_op_return_from_bytes = _wrap_bin(scriptpubkey_op_return_from_bytes, WALLY_SCRIPTSIG_OP_RETURN_MAX_LEN, resize=True)
+scriptpubkey_op_return_from_bytes = _wrap_bin(scriptpubkey_op_return_from_bytes, WALLY_SCRIPTPUBKEY_OP_RETURN_MAX_LEN, resize=True)
 scriptpubkey_p2pkh_from_bytes = _wrap_bin(scriptpubkey_p2pkh_from_bytes, WALLY_SCRIPTPUBKEY_P2PKH_LEN, resize=True)
 scriptpubkey_p2sh_from_bytes = _wrap_bin(scriptpubkey_p2sh_from_bytes, WALLY_SCRIPTPUBKEY_P2SH_LEN, resize=True)
 def _spkmfb_len_fn(sigs, threshold, flags):

--- a/src/test/test_script.py
+++ b/src/test/test_script.py
@@ -11,7 +11,7 @@ SCRIPT_SHA256  = 0x2
 
 MAX_OP_RETURN_LEN = 80
 
-SCRIPTSIG_OP_RETURN_MAX_LEN = 83
+SCRIPTPUBKEY_OP_RETURN_MAX_LEN = 83
 SCRIPTPUBKEY_P2PKH_LEN = 25
 SCRIPTPUBKEY_P2SH_LEN = 23
 HASH160_LEN = 20
@@ -47,7 +47,7 @@ class ScriptTests(unittest.TestCase):
         """Tests for creating OP_RETURN scriptPubKeys"""
         # Invalid args
         DATA, DATA_LEN = make_cbuffer('00' * MAX_OP_RETURN_LEN)
-        out, out_len = make_cbuffer('00' * SCRIPTSIG_OP_RETURN_MAX_LEN)
+        out, out_len = make_cbuffer('00' * SCRIPTPUBKEY_OP_RETURN_MAX_LEN)
         invalid_args = [
             (None, 20, 0, out, out_len), # Null bytes
             (DATA, DATA_LEN, 0x1, out, out_len), # Unsupported flags

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -68,6 +68,8 @@ static const unsigned char EMPTY_OUTPUT[9] = {
 static void assert_tx_assumptions(void)
 {
     BUILD_ASSERT(WALLY_TXHASH_LEN == SHA256_LEN);
+    BUILD_ASSERT(sizeof(DUMMY_SIG) == EC_SIGNATURE_DER_MAX_LEN + 1);
+    BUILD_ASSERT(sizeof(DUMMY_SIG) - 1 == EC_SIGNATURE_DER_MAX_LOW_R_LEN + 1);
 }
 /* LCOV_EXCL_END */
 
@@ -307,6 +309,9 @@ int wally_tx_witness_stack_set_dummy(struct wally_tx_witness_stack *stack,
     if (flags == WALLY_TX_DUMMY_SIG) {
         p = DUMMY_SIG;
         len = sizeof(DUMMY_SIG);
+    } else if (flags == WALLY_TX_DUMMY_SIG_LOW_R) {
+        p = DUMMY_SIG;
+        len = sizeof(DUMMY_SIG) - 1; /* Low-R signatures are always at least 1 byte shorter */
     } else if (flags != WALLY_TX_DUMMY_NULL)
         return WALLY_EINVAL;
     return wally_tx_witness_stack_set(stack, index, p, len);


### PR DESCRIPTION
Low-R signatures are always 1 byte shorter, so allow callers to handle this to get exact (or at least much closer to exact) fee estimates.

Also fix the constant name for OP_RETURN scriptpubkey length.