### PR TITLE
Allow non standard transaction versions

### DIFF
--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -11,7 +11,6 @@ extern "C" {
 #define WALLY_TX_SEQUENCE_FINAL 0xffffffff
 #define WALLY_TX_VERSION_1 1
 #define WALLY_TX_VERSION_2 2
-#define WALLY_TX_MAX_VERSION 2
 #define WALLY_TX_IS_ELEMENTS 1
 #define WALLY_TX_IS_ISSUANCE 2
 #define WALLY_TX_IS_PEGIN 4
@@ -257,7 +256,7 @@ WALLY_CORE_API int wally_tx_output_free(struct wally_tx_output *output);
 /**
  * Allocate and initialize a new transaction.
  *
- * :param version: The version of the transaction. Currently must be ``WALLY_TX_VERSION_2``.
+ * :param version: The version of the transaction.
  * :param locktime: The locktime of the transaction.
  * :param inputs_allocation_len: The number of inputs to pre-allocate space for.
  * :param outputs_allocation_len: The number of outputs to pre-allocate space for.

--- a/src/test/test_transaction.py
+++ b/src/test/test_transaction.py
@@ -29,8 +29,6 @@ class TransactionTests(unittest.TestCase):
             (utf8('00'*5), 0, pointer(wally_tx())), # Short hex
             (TX_FAKE_HEX, 0, None), # Empty output
             (TX_FAKE_HEX, 2, pointer(wally_tx())), # Unsupported flag
-            (utf8('00')+TX_FAKE_HEX[2:], 0, pointer(wally_tx())), # Unsupported version
-            (utf8('03')+TX_FAKE_HEX[2:], 0, pointer(wally_tx())), # Unsupported version
             (TX_FAKE_HEX[:9]+utf8('0')+TX_FAKE_HEX[92:], 0, pointer(wally_tx())), # No inputs
             (TX_FAKE_HEX[:93]+utf8('0')+TX_FAKE_HEX[112:], 0, pointer(wally_tx())), # No outputs
             (TX_WITNESS_HEX[:11]+utf8('0')+TX_WITNESS_HEX[12:], 0, pointer(wally_tx())), # Invalid witness flag
@@ -39,6 +37,8 @@ class TransactionTests(unittest.TestCase):
 
         for args in [
             (TX_HEX, 0, pointer(wally_tx())),
+            (utf8('00')+TX_HEX[2:], 0, pointer(wally_tx())),
+            (utf8('ff')+TX_FAKE_HEX[2:], 0, pointer(wally_tx())),
             (TX_FAKE_HEX, 0, pointer(wally_tx())),
             (TX_WITNESS_HEX, 0, pointer(wally_tx())),
             ]:

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -2206,8 +2206,6 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
         return WALLY_EINVAL;
 
     p += uint32_from_le_bytes(p, &tmp_tx.version);
-    if (!tmp_tx.version || tmp_tx.version > WALLY_TX_MAX_VERSION)
-        return WALLY_EINVAL;
 
     if (is_elements)
         *expect_witnesses = *p++ != 0;


### PR DESCRIPTION
Although transactions with version 0 or above the `CURRENT_VERSION` are not standard, it should be possible to serialize/deserialize them.