### PR TITLE
update debian/ubuntu builders, ndk to r19

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 linux_release:
-  image: greenaddress/wallycore@sha256:9e7f9991cfe657926db21d12d34c58ce5ea45eef83cfde614138c69cfa4ace84
+  image: greenaddress/wallycore@sha256:ab55c35391af5e762a22db9f532b995b908a12c1bcbce911c528514b0f7295a1
   artifacts:
     expire_in: 1 day
     name: wallycore-bindings
@@ -19,7 +19,7 @@ linux_release:
     - gzip -9 wally_dist/wallycore-android-jni.tar
 
 linux_py2_debug:
-  image: greenaddress/wallycore@sha256:9e7f9991cfe657926db21d12d34c58ce5ea45eef83cfde614138c69cfa4ace84
+  image: greenaddress/wallycore@sha256:ab55c35391af5e762a22db9f532b995b908a12c1bcbce911c528514b0f7295a1
   tags:
     - ga
   script:
@@ -29,7 +29,7 @@ linux_py2_debug:
     - DEBUG_WALLY=--enable-debug ./tools/build_js_bindings.sh
 
 linux_py3_debug:
-  image: greenaddress/wallycore@sha256:9e7f9991cfe657926db21d12d34c58ce5ea45eef83cfde614138c69cfa4ace84
+  image: greenaddress/wallycore@sha256:ab55c35391af5e762a22db9f532b995b908a12c1bcbce911c528514b0f7295a1
   tags:
     - ga
   script:
@@ -38,7 +38,7 @@ linux_py3_debug:
     - PYTHON_VERSION=3.5 DEBUG_WALLY=--enable-debug ./tools/travis_build.sh
 
 ubuntu_release:
-  image: greenaddress/wallycore@sha256:0cfdaf0b1f62981e3da321da003d09fe9e1fd6f0b052e64121031ff3b5263ad8
+  image: greenaddress/wallycore@sha256:4870ea7732fe2af9129b35c9a40a7836bb8f9346df41e0a1a39d69f4ebe0e11e
   artifacts:
     expire_in: 1 day
     name: wallycore-bindings
@@ -124,7 +124,7 @@ windows10_release:
     - tools\msvc\wheel.bat
 
 apidocs:
-  image: greenaddress/wallycore@sha256:9e7f9991cfe657926db21d12d34c58ce5ea45eef83cfde614138c69cfa4ace84
+  image: greenaddress/wallycore@sha256:ab55c35391af5e762a22db9f532b995b908a12c1bcbce911c528514b0f7295a1
   artifacts:
     expire_in: 14 days
     name: wallycore-apidocs

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ used as an example for your own python projects.
 ### Android
 
 Android builds are currently supported for all Android binary targets using
-a toolchain directory created with the Android NDK tool
-`make_standalone_toolchain.py`. The script `tools/android_helpers.sh` can be
-sourced from the shell or scripts to make it easier to produce builds:
+the Android NDK. The script `tools/android_helpers.sh` can be sourced from
+the shell or scripts to make it easier to produce builds:
 
 ```
 $ export ANDROID_HOME=/opt/android-sdk
@@ -123,7 +122,7 @@ $ ./tools/cleanup.sh
 $ ./tools/autogen.sh
 
 # See the comments in tools/android_helpers.sh for arguments
-$ android_build_wally armeabi-v7a $PWD/toolchain-armeabi-v7a 19 "--enable-swig-java"
+$ android_build_wally armeabi-v7a $ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64 19 "--enable-swig-java"
 ```
 
 The script `tools/build_android_libraries.sh` builds the Android release files and

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:stretch@sha256:802706fa62e75c96fff96ada0e8ca11f570895ae2e9ba4a9d409981750ca544c
+FROM debian:stretch@sha256:21ac5961a3038a839f6fa92ec4583c90f9eb6ca8f580598cde19d35d0f4d8fa6
 COPY stretch_deps.sh /deps.sh
 RUN /deps.sh && rm /deps.sh
 VOLUME /wallycore
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-ENV ANDROID_NDK=/opt/android-ndk-r18b
+ENV ANDROID_NDK=/opt/android-ndk-r19

--- a/contrib/Dockerfile_ubuntu
+++ b/contrib/Dockerfile_ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
+FROM ubuntu:18.04@sha256:945039273a7b927869a07b375dc3148de16865de44dec8398672977e050a072e
 COPY ubuntu_18.04_deps.sh /deps.sh
 RUN /deps.sh && rm /deps.sh
 VOLUME /wallycore

--- a/contrib/stretch_deps.sh
+++ b/contrib/stretch_deps.sh
@@ -1,10 +1,9 @@
 #! /usr/bin/env bash
 set -e
 
-export NDK_FILENAME=android-ndk-r18b-linux-x86_64.zip
+export NDK_FILENAME=android-ndk-r19-linux-x86_64.zip
 
 dpkg --add-architecture i386
-sed -i 's/deb.debian.org/httpredir.debian.org/g' /etc/apt/sources.list
 
 apt-get update -qq
 apt-get upgrade -yqq

--- a/tools/build_android_libraries.sh
+++ b/tools/build_android_libraries.sh
@@ -32,7 +32,10 @@ for arch in $ARCH_LIST; do
     fi
 
     # Location of the NDK tools to build with
-    toolsdir="$PWD/toolchain-$arch"
+    toolsdir=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    if [ "$(uname)" == "Darwin" ]; then
+        toolsdir=$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64
+    fi
 
     # What we want built
     useropts="--enable-swig-java $ENABLE_ELEMENTS"
@@ -42,7 +45,13 @@ for arch in $ARCH_LIST; do
 
     # Copy the build result
     mkdir -p $PWD/release/lib/$arch
-    $toolsdir/bin/*linux*-strip -o $PWD/release/lib/$arch/libwallycore.so $PWD/src/.libs/libwallycore.so
+    archfilename=$arch
+    case $arch in
+        armeabi-v7a) archfilename=arm;;
+        arm64-v8a) archfilename=aarch64;;
+        x86) archfilename=i686;;
+    esac
+    $toolsdir/bin/$archfilename-linux-android*-strip -o $PWD/release/lib/$arch/libwallycore.so $PWD/src/.libs/libwallycore.so
 done
 
 mkdir -p $PWD/release/include $PWD/release/src/swig_java/src/com/blockstream/libwally


### PR DESCRIPTION
This updates the debian/ubuntu docker bases to latest packages for their LTS/stable versions and also updates the android ndk to r19