### PR TITLE
Ecmult precomputation fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ else:
             extra_build_options = os.getenv('ENABLE_ELEMENTS', '')
             call('./tools/cleanup.sh')
             call('./tools/autogen.sh')
-            call('./configure --enable-swig-python {}'.format(extra_build_options))
+            call('./configure --enable-swig-python --enable-ecmult-static-precomputation {}'.format(extra_build_options))
             call('make -j{}'.format(multiprocessing.cpu_count()))
 
             # Copy the so that has just been built to the build_dir that distutils expects it to be in

--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -151,7 +151,6 @@ endif
 
 if USE_ECMULT_STATIC_PRECOMPUTATION
 CPPFLAGS_FOR_BUILD +=-I$(top_srcdir)
-CFLAGS_FOR_BUILD += -Wall -Wextra -Wno-unused-function
 
 gen_context_OBJECTS = gen_context.o
 gen_context_BIN = gen_context$(BUILD_EXEEXT)

--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -202,6 +202,8 @@ if test x"$use_ecmult_static_precomputation" != x"no"; then
   CFLAGS="$CFLAGS_FOR_BUILD"
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS_FOR_BUILD"
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS_FOR_BUILD"
 
   warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
   saved_CFLAGS="$CFLAGS"
@@ -222,6 +224,7 @@ if test x"$use_ecmult_static_precomputation" != x"no"; then
   CFLAGS_FOR_BUILD="$CFLAGS"
   CPPFLAGS="$SAVE_CPPFLAGS"
   CFLAGS="$SAVE_CFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
   CC="$SAVE_CC"
   cross_compiling=$save_cross_compiling
 

--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -196,25 +196,45 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_popcount(0);}]])],
 if test x"$use_ecmult_static_precomputation" != x"no"; then
   save_cross_compiling=$cross_compiling
   cross_compiling=no
-  TEMP_CC="$CC"
+  SAVE_CC="$CC"
   CC="$CC_FOR_BUILD"
-  AC_MSG_CHECKING([native compiler: ${CC_FOR_BUILD}])
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS_FOR_BUILD"
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS_FOR_BUILD"
+
+  warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
+  saved_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $warn_CFLAGS_FOR_BUILD"
+  AC_MSG_CHECKING([if native ${CC_FOR_BUILD} supports ${warn_CFLAGS_FOR_BUILD}])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+      [ AC_MSG_RESULT([yes]) ],
+      [ AC_MSG_RESULT([no])
+        CFLAGS="$saved_CFLAGS"
+      ])
+
+  AC_MSG_CHECKING([for working native compiler: ${CC_FOR_BUILD}])
   AC_RUN_IFELSE(
     [AC_LANG_PROGRAM([], [return 0])],
     [working_native_cc=yes],
     [working_native_cc=no],[dnl])
-  CC="$TEMP_CC"
+
+  CFLAGS_FOR_BUILD="$CFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  CFLAGS="$SAVE_CFLAGS"
+  CC="$SAVE_CC"
   cross_compiling=$save_cross_compiling
 
   if test x"$working_native_cc" = x"no"; then
+    AC_MSG_RESULT([no])
     set_precomp=no
     if test x"$use_ecmult_static_precomputation" = x"yes";  then
-      AC_MSG_ERROR([${CC_FOR_BUILD} does not produce working binaries. Please set CC_FOR_BUILD])
+      AC_MSG_ERROR([native compiler ${CC_FOR_BUILD} does not produce working binaries. Please set CC_FOR_BUILD and/or CFLAGS_FOR_BUILD.])
     else
-      AC_MSG_RESULT([${CC_FOR_BUILD} does not produce working binaries. Please set CC_FOR_BUILD])
+      AC_MSG_WARN([Disabling statically generated ecmult table because the native compiler ${CC_FOR_BUILD} does not produce working binaries. Please set CC_FOR_BUILD and/or CFLAGS_FOR_BUILD.])
     fi
   else
-    AC_MSG_RESULT([ok])
+    AC_MSG_RESULT([yes])
     set_precomp=yes
   fi
 else

--- a/tools/build_android_libraries.sh
+++ b/tools/build_android_libraries.sh
@@ -38,7 +38,7 @@ for arch in $ARCH_LIST; do
     fi
 
     # What we want built
-    useropts="--enable-swig-java $ENABLE_ELEMENTS"
+    useropts="--enable-swig-java $ENABLE_ELEMENTS --enable-ecmult-static-precomputation"
 
     # Configure and build with the above options
     android_build_wally $arch $toolsdir $api $useropts

--- a/tools/build_js_bindings.sh
+++ b/tools/build_js_bindings.sh
@@ -4,7 +4,7 @@ set -e
 
 tools/cleanup.sh
 tools/autogen.sh
-./configure --enable-js-wrappers --disable-swig-python --disable-swig-java $DEBUG_WALLY $ENABLE_ELEMENTS
+./configure --enable-js-wrappers --disable-swig-python --disable-swig-java --enable-ecmult-static-precomputation $DEBUG_WALLY $ENABLE_ELEMENTS
 num_jobs=4
 if [ -f /proc/cpuinfo ]; then
     num_jobs=$(grep ^processor /proc/cpuinfo | wc -l)


### PR DESCRIPTION
this applies a secp fix from upstream https://github.com/bitcoin-core/secp256k1/pull/584 and an additional fix to enable ecmult-static-precomputation which is otherwise automatically on by default

It then explicitly enables ecmult-static-precomputation explicitly for all the artifacts (python, java ndk and js bindings) to avoid it silently not being enabled.