### PR TITLE
Expose wally_scriptpubkey_multisig_from_bytes to nodejs

### DIFF
--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -1,4 +1,7 @@
-var wally = require('./wally');
+const wally = require('./wally');
+const EC_PUBLIC_KEY_LEN = 33;
+const VERSION_PREFIX_LIQUID = '4b'
+var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 wally.wally_sha256(Buffer.from('test', 'ascii')).then(function(uint8Array) {
   console.log(Buffer.from(uint8Array).toString('hex'))
@@ -9,17 +12,95 @@ wally.wally_base58_from_bytes(Buffer.from('xyz', 'ascii'), 0).then(function(s) {
     console.log(Buffer.from(bytes_).toString('ascii'));
   });
 });
-var zeroes = [];
-for (var i = 0; i < 16; ++i) {
-    zeroes.push(0);
-}
-wally.bip32_key_from_seed(Buffer.from(zeroes), 0x0488ADE4, 0).then(function(s) {
+
+wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
   wally.wally_base58_from_bytes(s, 1).then(function (s) {
-    console.log('privkey:', s);
+    console.log('xpriv m/0:', s);
   });
-  wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
-    wally.wally_base58_from_bytes(pub, 1).then(function (s) {
-      console.log('pubkey:', s);
+
+  wally.wally_ec_public_key_from_private_key(s.slice(46, 78)).then(function(master_pubkey) {
+    console.log('M/0: ', Buffer.from(master_pubkey));
+  });
+
+  wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
+    wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
+      console.log('xpriv m/0/0:', base58_xpriv);
     });
   });
+
+  wally.bip32_pubkey_from_parent(s, 0, 0).then(function (xpub_0_0) {
+    wally.wally_base58_from_bytes(xpub_0_0, 1).then(function (base58_xpub) {
+      console.log('xpub M/0/0:', base58_xpub);
+    });
+
+    wally.bip32_pubkey_from_parent(xpub_0_0, 1, 1).then(function (xpub_0_0_1) {
+      wally.wally_base58_from_bytes(xpub_0_0_1, 1).then(function (base58_xpub) {
+        console.log('xpub M/0/0/1:', base58_xpub);
+      });
+
+      var version = Buffer.from('0014', 'hex');
+
+      wally.wally_hash160(xpub_0_0_1.slice(45, 78)).then((hash160) => {
+        return wally.wally_addr_segwit_from_bytes(Buffer.concat([version, Buffer.from(hash160)]),'tb',0);
+      }).then((addr) => {
+        console.log('bech32: addr: ', addr)
+      });
+    });
+  });
+});
+
+// Multisig Address
+wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
+.then(function(s) {
+
+  //Derive child pubkey from parent xpub in bytes
+  var _pubkey1 = wally.bip32_pubkey_from_parent(s, 1, 0);
+  var _pubkey2 = wally.bip32_pubkey_from_parent(s, 2, 0);
+
+  return Promise.all([_pubkey1, _pubkey2]);
+  
+}).then((xpubkeys) => {
+  const pubkey1 = xpubkeys[0].slice(45, 78);
+  const pubkey2 = xpubkeys[1].slice(45, 78);
+  const byt_pubkeys = Buffer.concat([pubkey1, pubkey2]);
+
+  // build redeem script
+  return wally.wally_scriptpubkey_multisig_from_bytes(
+    byt_pubkeys,
+    2,
+    0,
+    (byt_pubkeys.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3);
+}).then((redeem_script) => {
+  console.log(Buffer.from(redeem_script).toString('hex'));
+
+  // hash redeem script
+  return wally.wally_hash160(redeem_script);
+
+}).then((script_hash) => {
+  const prefix = Buffer.from(VERSION_PREFIX_LIQUID, 'hex');
+
+  // base58 encode with adding checksum
+  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script_hash]), 1);
+  
+}).then((addr) => {
+  console.log('multisig addr: ', addr);
+});
+
+wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
+.then(function(s) {
+
+  return wally.bip32_pubkey_from_parent(s, 0, 1);
+  
+}).then((xpubkey) => {
+  const pubkey = xpubkey.slice(45, 78);
+ 
+  return wally.wally_hash160(pubkey);
+
+}).then((script) => {
+  const prefix = Buffer.from('eb', 'hex');
+
+  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), 1);
+
+}).then((addresses) => {
+  console.log(addresses);
 });

--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -11,7 +11,7 @@ TEMPLATE='''#include <nan.h>
 #include "../include/wally_elements.h"
 #include "../include/wally_script.h"
 #include <vector>
-
+#include <iostream>
 namespace {
 
 static struct wally_operations w_ops;
@@ -280,6 +280,18 @@ def _generate_nan(funcname, f):
                 'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
                 'unsigned char *res_ptr = Allocate(res_size, ret);',
                 'size_t out_size;'
+            ])
+            args.append('res_ptr')
+            args.append('res_size')
+            args.append('&out_size')
+            postprocessing.extend([
+                'LocalObject res = AllocateBuffer(res_ptr, out_size, res_size, ret);'
+            ])
+        elif arg == 'out_bytes_sized_script':
+            output_args.extend([
+                'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
+                'unsigned char *res_ptr = Allocate(res_size, ret);',
+                'size_t out_size;',
             ])
             args.append('res_ptr')
             args.append('res_size')

--- a/src/wrap_js/makewrappers/wrap.py
+++ b/src/wrap_js/makewrappers/wrap.py
@@ -80,6 +80,12 @@ FUNCS = [
         'uint32_t[flags]', 'out_bytes_sized'
     ], out_size='Math.ceil(_arguments[2].length / 16) * 16 + 16')),
 
+    # Script:
+    ('wally_scriptpubkey_multisig_from_bytes', F([
+        'const_bytes[bytes]', 'uint32_t[threshold]', 'uint32_t[flags]', 
+        'out_bytes_sized' 
+    ], out_size='Math.ceil(_arguments[0].length / 33) * 34 + 3')),
+
     # Scrypt:
     ('wally_scrypt', F([
         'const_bytes[passwd]', 'const_bytes[salt]',
@@ -140,6 +146,10 @@ FUNCS = [
     ('bip32_key_get_priv_key', F([
         'bip32_in', 'out_bytes_fixedsized'
     ], out_size='32')),
+
+    ('wally_ec_public_key_from_private_key', F([
+        'const_bytes[key]', 'out_bytes_fixedsized'
+    ], out_size='33')),
 
     ('wally_format_bitcoin_message', F([
         'const_bytes[message]', 'uint32_t[flags]',

--- a/src/wrap_js/test/test_script.js
+++ b/src/wrap_js/test/test_script.js
@@ -1,0 +1,24 @@
+var wally = require('../wally');
+var test = require('tape');
+
+const EC_PUBLIC_KEY_LEN = 33;
+var pubkeys = [
+    '02ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e99',
+    '03afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f3'
+];
+
+test('Script', function(t) {
+    t.plan(1);
+
+    var pubkey_bytes = Buffer.from(pubkeys[0] + pubkeys[1], 'hex');
+    var redeem_script = '522102ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e992103afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f352ae';
+    
+    wally.wally_scriptpubkey_multisig_from_bytes(
+        pubkey_bytes,
+        2,
+        0,
+        (pubkey_bytes.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3
+    ).then((res) => {
+        t.equal(Buffer.from(res).toString('hex'), redeem_script);
+    });
+});


### PR DESCRIPTION
This exposes wally_scriptpubkey_multisig_from_bytes to the library of nodejs. It will come in handy for clients apps based on javascript to create multi signature address.