### PR TITLE
multisig addr nodejs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -283,6 +283,7 @@ endif
 	$(AM_V_at)wrap_js/node_modules/.bin/tape wrap_js/test/test_bip39.js
 	$(AM_V_at)wrap_js/node_modules/.bin/tape wrap_js/test/test_hash.js
 	$(AM_V_at)wrap_js/node_modules/.bin/tape wrap_js/test/test_scrypt.js
+	$(AM_V_at)wrap_js/node_modules/.bin/tape wrap_js/test/test_script.js
 endif
 endif # SHARED_BUILD_ENABLED
 endif # RUN_TESTS

--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -1,4 +1,7 @@
-var wally = require('./wally');
+const wally = require('./wally');
+const EC_PUBLIC_KEY_LEN = 33;
+const VERSION_PREFIX_LIQUID = '4b'
+var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 wally.wally_sha256(Buffer.from('test', 'ascii')).then(function(uint8Array) {
   console.log(Buffer.from(uint8Array).toString('hex'))
@@ -9,17 +12,95 @@ wally.wally_base58_from_bytes(Buffer.from('xyz', 'ascii'), 0).then(function(s) {
     console.log(Buffer.from(bytes_).toString('ascii'));
   });
 });
-var zeroes = [];
-for (var i = 0; i < 16; ++i) {
-    zeroes.push(0);
-}
-wally.bip32_key_from_seed(Buffer.from(zeroes), 0x0488ADE4, 0).then(function(s) {
+
+wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
   wally.wally_base58_from_bytes(s, 1).then(function (s) {
-    console.log('privkey:', s);
+    console.log('xpriv m/0:', s);
   });
-  wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
-    wally.wally_base58_from_bytes(pub, 1).then(function (s) {
-      console.log('pubkey:', s);
+
+  wally.wally_ec_public_key_from_private_key(s.slice(46, 78)).then(function(master_pubkey) {
+    console.log('M/0: ', Buffer.from(master_pubkey));
+  });
+
+  wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
+    wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
+      console.log('xpriv m/0/0:', base58_xpriv);
     });
   });
+
+  wally.bip32_pubkey_from_parent(s, 0, 0).then(function (xpub_0_0) {
+    wally.wally_base58_from_bytes(xpub_0_0, 1).then(function (base58_xpub) {
+      console.log('xpub M/0/0:', base58_xpub);
+    });
+
+    wally.bip32_pubkey_from_parent(xpub_0_0, 1, 1).then(function (xpub_0_0_1) {
+      wally.wally_base58_from_bytes(xpub_0_0_1, 1).then(function (base58_xpub) {
+        console.log('xpub M/0/0/1:', base58_xpub);
+      });
+
+      var version = Buffer.from('0014', 'hex');
+
+      wally.wally_hash160(xpub_0_0_1.slice(45, 78)).then((hash160) => {
+        return wally.wally_addr_segwit_from_bytes(Buffer.concat([version, Buffer.from(hash160)]),'tb',0);
+      }).then((addr) => {
+        console.log('bech32: addr: ', addr)
+      });
+    });
+  });
+});
+
+// Multisig Address
+wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
+.then(function(s) {
+
+  //Derive child pubkey from parent xpub in bytes
+  var _pubkey1 = wally.bip32_pubkey_from_parent(s, 1, 0);
+  var _pubkey2 = wally.bip32_pubkey_from_parent(s, 2, 0);
+
+  return Promise.all([_pubkey1, _pubkey2]);
+  
+}).then((xpubkeys) => {
+  const pubkey1 = xpubkeys[0].slice(45, 78);
+  const pubkey2 = xpubkeys[1].slice(45, 78);
+  const byt_pubkeys = Buffer.concat([pubkey1, pubkey2]);
+
+  // build redeem script
+  return wally.wally_scriptpubkey_multisig_from_bytes(
+    byt_pubkeys,
+    2,
+    0,
+    (byt_pubkeys.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3);
+}).then((redeem_script) => {
+  console.log(Buffer.from(redeem_script).toString('hex'));
+
+  // hash redeem script
+  return wally.wally_hash160(redeem_script);
+
+}).then((script_hash) => {
+  const prefix = Buffer.from(VERSION_PREFIX_LIQUID, 'hex');
+
+  // base58 encode with adding checksum
+  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script_hash]), 1);
+  
+}).then((addr) => {
+  console.log('multisig addr: ', addr);
+});
+
+wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
+.then(function(s) {
+
+  return wally.bip32_pubkey_from_parent(s, 0, 1);
+  
+}).then((xpubkey) => {
+  const pubkey = xpubkey.slice(45, 78);
+ 
+  return wally.wally_hash160(pubkey);
+
+}).then((script) => {
+  const prefix = Buffer.from('eb', 'hex');
+
+  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), 1);
+
+}).then((addresses) => {
+  console.log(addresses);
 });

--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -1,6 +1,6 @@
 const wally = require('./wally');
 const EC_PUBLIC_KEY_LEN = 33;
-const VERSION_PREFIX_LIQUID = '4b'
+const VERSION_PREFIX_LIQUID = '4b';
 var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 wally.wally_sha256(Buffer.from('test', 'ascii')).then(function(uint8Array) {

--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -1,4 +1,4 @@
-var wally = require('./wally');
+const wally = require('./wally');
 
 wally.wally_sha256(Buffer.from('test', 'ascii')).then(function(uint8Array) {
   console.log(Buffer.from(uint8Array).toString('hex'))
@@ -10,13 +10,13 @@ wally.wally_base58_from_bytes(Buffer.from('xyz', 'ascii'), 0).then(function(s) {
   });
 });
 
-var seed = Buffer.from('00000000000000000000000000000000', 'hex');
-wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
+const seed = Buffer.from('00000000000000000000000000000000', 'hex');
+wally.bip32_key_from_seed(seed, wally.BIP32_VER_MAIN_PRIVATE, 0).then(function(s) {
   wally.wally_base58_from_bytes(s, 1).then(function (s) {
     console.log('privkey:', s);
   });
   wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
-    wally.wally_base58_from_bytes(pub, 1).then(function (s) {
+    wally.wally_base58_from_bytes(pub,  wally.BASE58_FLAG_CHECKSUM).then(function (s) {
       console.log('pubkey:', s);
     });
   });

--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -58,7 +58,7 @@ wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex')
   var _pubkey2 = wally.bip32_pubkey_from_parent(s, 2, 0);
 
   return Promise.all([_pubkey1, _pubkey2]);
-  
+
 }).then((xpubkeys) => {
   const pubkey1 = xpubkeys[0].slice(45, 78);
   const pubkey2 = xpubkeys[1].slice(45, 78);
@@ -81,7 +81,7 @@ wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex')
 
   // base58 encode with adding checksum
   return wally.wally_base58_from_bytes(Buffer.concat([prefix, script_hash]), 1);
-  
+
 }).then((addr) => {
   console.log('multisig addr: ', addr);
 });
@@ -90,10 +90,10 @@ wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex')
 .then(function(s) {
 
   return wally.bip32_pubkey_from_parent(s, 0, 1);
-  
+
 }).then((xpubkey) => {
   const pubkey = xpubkey.slice(45, 78);
- 
+
   return wally.wally_hash160(pubkey);
 
 }).then((script) => {

--- a/src/wrap_js/example.js
+++ b/src/wrap_js/example.js
@@ -1,7 +1,4 @@
-const wally = require('./wally');
-const EC_PUBLIC_KEY_LEN = 33;
-const VERSION_PREFIX_LIQUID = '4b';
-var seed = Buffer.from('00000000000000000000000000000000', 'hex');
+var wally = require('./wally');
 
 wally.wally_sha256(Buffer.from('test', 'ascii')).then(function(uint8Array) {
   console.log(Buffer.from(uint8Array).toString('hex'))
@@ -13,94 +10,14 @@ wally.wally_base58_from_bytes(Buffer.from('xyz', 'ascii'), 0).then(function(s) {
   });
 });
 
+var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
   wally.wally_base58_from_bytes(s, 1).then(function (s) {
-    console.log('xpriv m/0:', s);
+    console.log('privkey:', s);
   });
-
-  wally.wally_ec_public_key_from_private_key(s.slice(46, 78)).then(function(master_pubkey) {
-    console.log('M/0: ', Buffer.from(master_pubkey));
-  });
-
-  wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
-    wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
-      console.log('xpriv m/0/0:', base58_xpriv);
+  wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
+    wally.wally_base58_from_bytes(pub, 1).then(function (s) {
+      console.log('pubkey:', s);
     });
   });
-
-  wally.bip32_pubkey_from_parent(s, 0, 0).then(function (xpub_0_0) {
-    wally.wally_base58_from_bytes(xpub_0_0, 1).then(function (base58_xpub) {
-      console.log('xpub M/0/0:', base58_xpub);
-    });
-
-    wally.bip32_pubkey_from_parent(xpub_0_0, 1, 1).then(function (xpub_0_0_1) {
-      wally.wally_base58_from_bytes(xpub_0_0_1, 1).then(function (base58_xpub) {
-        console.log('xpub M/0/0/1:', base58_xpub);
-      });
-
-      var version = Buffer.from('0014', 'hex');
-
-      wally.wally_hash160(xpub_0_0_1.slice(45, 78)).then((hash160) => {
-        return wally.wally_addr_segwit_from_bytes(Buffer.concat([version, Buffer.from(hash160)]),'tb',0);
-      }).then((addr) => {
-        console.log('bech32: addr: ', addr)
-      });
-    });
-  });
-});
-
-// Multisig Address
-wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
-.then(function(s) {
-
-  //Derive child pubkey from parent xpub in bytes
-  var _pubkey1 = wally.bip32_pubkey_from_parent(s, 1, 0);
-  var _pubkey2 = wally.bip32_pubkey_from_parent(s, 2, 0);
-
-  return Promise.all([_pubkey1, _pubkey2]);
-
-}).then((xpubkeys) => {
-  const pubkey1 = xpubkeys[0].slice(45, 78);
-  const pubkey2 = xpubkeys[1].slice(45, 78);
-  const byt_pubkeys = Buffer.concat([pubkey1, pubkey2]);
-
-  // build redeem script
-  return wally.wally_scriptpubkey_multisig_from_bytes(
-    byt_pubkeys,
-    2,
-    0,
-    (byt_pubkeys.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3);
-}).then((redeem_script) => {
-  console.log(Buffer.from(redeem_script).toString('hex'));
-
-  // hash redeem script
-  return wally.wally_hash160(redeem_script);
-
-}).then((script_hash) => {
-  const prefix = Buffer.from(VERSION_PREFIX_LIQUID, 'hex');
-
-  // base58 encode with adding checksum
-  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script_hash]), 1);
-
-}).then((addr) => {
-  console.log('multisig addr: ', addr);
-});
-
-wally.bip32_key_from_seed(Buffer.from('00000000000000000000000000000000', 'hex'), 0x0488ADE4, 0)
-.then(function(s) {
-
-  return wally.bip32_pubkey_from_parent(s, 0, 1);
-
-}).then((xpubkey) => {
-  const pubkey = xpubkey.slice(45, 78);
-
-  return wally.wally_hash160(pubkey);
-
-}).then((script) => {
-  const prefix = Buffer.from('eb', 'hex');
-
-  return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), 1);
-
-}).then((addresses) => {
-  console.log(addresses);
 });

--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -274,23 +274,11 @@ def _generate_nan(funcname, f):
                 '}',
             ])
             result_wrap = 'str_res'
-        elif arg == 'out_bytes_sized':
+        elif arg.startswith('out_bytes_sized'):
             output_args.extend([
                 'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
                 'unsigned char *res_ptr = Allocate(res_size, ret);',
                 'size_t out_size;'
-            ])
-            args.append('res_ptr')
-            args.append('res_size')
-            args.append('&out_size')
-            postprocessing.extend([
-                'LocalObject res = AllocateBuffer(res_ptr, out_size, res_size, ret);'
-            ])
-        elif arg == 'out_bytes_sized_script':
-            output_args.extend([
-                'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
-                'unsigned char *res_ptr = Allocate(res_size, ret);',
-                'size_t out_size;',
             ])
             args.append('res_ptr')
             args.append('res_size')

--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -11,7 +11,7 @@ TEMPLATE='''#include <nan.h>
 #include "../include/wally_elements.h"
 #include "../include/wally_script.h"
 #include <vector>
-
+#include <iostream>
 namespace {
 
 static struct wally_operations w_ops;
@@ -280,6 +280,18 @@ def _generate_nan(funcname, f):
                 'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
                 'unsigned char *res_ptr = Allocate(res_size, ret);',
                 'size_t out_size;'
+            ])
+            args.append('res_ptr')
+            args.append('res_size')
+            args.append('&out_size')
+            postprocessing.extend([
+                'LocalObject res = AllocateBuffer(res_ptr, out_size, res_size, ret);'
+            ])
+        elif arg == 'out_bytes_sized_script':
+            output_args.extend([
+                'const uint32_t res_size = GetUInt32(info, %s, ret);' % i,
+                'unsigned char *res_ptr = Allocate(res_size, ret);',
+                'size_t out_size;',
             ])
             args.append('res_ptr')
             args.append('res_size')

--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -11,7 +11,6 @@ TEMPLATE='''#include <nan.h>
 #include "../include/wally_elements.h"
 #include "../include/wally_script.h"
 #include <vector>
-#include <iostream>
 namespace {
 
 static struct wally_operations w_ops;

--- a/src/wrap_js/makewrappers/wrap.py
+++ b/src/wrap_js/makewrappers/wrap.py
@@ -146,6 +146,9 @@ FUNCS = [
     ('bip32_key_get_priv_key', F([
         'bip32_in', 'out_bytes_fixedsized'
     ], out_size='32')),
+    ('bip32_key_get_pub_key', F([
+        'bip32_in', 'out_bytes_fixedsized'
+    ], out_size='33')),
 
     ('wally_ec_public_key_from_private_key', F([
         'const_bytes[key]', 'out_bytes_fixedsized'

--- a/src/wrap_js/makewrappers/wrap.py
+++ b/src/wrap_js/makewrappers/wrap.py
@@ -82,8 +82,8 @@ FUNCS = [
 
     # Script:
     ('wally_scriptpubkey_multisig_from_bytes', F([
-        'const_bytes[bytes]', 'uint32_t[threshold]', 'uint32_t[flags]', 
-        'out_bytes_sized' 
+        'const_bytes[bytes]', 'uint32_t[threshold]', 'uint32_t[flags]',
+        'out_bytes_sized'
     ], out_size='Math.ceil(_arguments[0].length / 33) * 34 + 3')),
 
     # Scrypt:

--- a/src/wrap_js/makewrappers/wrap.py
+++ b/src/wrap_js/makewrappers/wrap.py
@@ -80,6 +80,12 @@ FUNCS = [
         'uint32_t[flags]', 'out_bytes_sized'
     ], out_size='Math.ceil(_arguments[2].length / 16) * 16 + 16')),
 
+    # Script:
+    ('wally_scriptpubkey_multisig_from_bytes', F([
+        'const_bytes[bytes]', 'uint32_t[threshold]', 'uint32_t[flags]', 
+        'out_bytes_sized' 
+    ], out_size='Math.ceil(_arguments[0].length / 33) * 34 + 3')),
+
     # Scrypt:
     ('wally_scrypt', F([
         'const_bytes[passwd]', 'const_bytes[salt]',
@@ -140,6 +146,10 @@ FUNCS = [
     ('bip32_key_get_priv_key', F([
         'bip32_in', 'out_bytes_fixedsized'
     ], out_size='32')),
+
+    ('wally_ec_public_key_from_private_key', F([
+        'const_bytes[key]', 'out_bytes_fixedsized'
+    ], out_size='33')),
 
     ('wally_format_bitcoin_message', F([
         'const_bytes[message]', 'uint32_t[flags]',

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -26,13 +26,15 @@ test('BIP32 from seed + derivation', function(t) {
       });
     });
 
-    wally.wally_ec_public_key_from_private_key(s.slice(46, 78)).then(function(master_pubkey) {
-      t.equal(
-        Buffer.from(master_pubkey).toString('hex'),
-        '02be99138b48b430a8ee40bf8b56c8ebc584c363774010a9bfe549a87126e61746',
-        'M/0'
-      );
-    });
+    wally.bip32_key_get_priv_key(s).then(function(privkey) {
+      wally.wally_ec_public_key_from_private_key(privkey).then(function(master_pubkey) {
+        t.equal(
+          Buffer.from(master_pubkey).toString('hex'),
+          '02be99138b48b430a8ee40bf8b56c8ebc584c363774010a9bfe549a87126e61746',
+          'M/0'
+        );
+      });
+    })
 
     wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
       wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
@@ -72,7 +74,8 @@ test('BIP32 from seed to address', function(t) {
   wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
     return wally.bip32_pubkey_from_parent(s, 0, 1);
   }).then((xpubkey) => {
-    const pubkey = xpubkey.slice(45, 78);
+    return wally.bip32_key_get_pub_key(xpubkey);
+  }).then((pubkey) => {
     return wally.wally_hash160(pubkey);
   }).then((script) => {
     const prefix = Buffer.from('eb', 'hex');

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -78,7 +78,7 @@ test('BIP32 from seed to address', function(t) {
   }).then((pubkey) => {
     return wally.wally_hash160(pubkey);
   }).then((script) => {
-    const prefix = Buffer.from('eb', 'hex');
+    const prefix = new Uint8Array([0xeb]);
     return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), wally.BASE58_FLAG_CHECKSUM);
   }).then((address) => {
     t.equal(

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -31,36 +31,36 @@ test('BIP32 from seed + derivation', function(t) {
         t.equal(
           Buffer.from(master_pubkey).toString('hex'),
           '02be99138b48b430a8ee40bf8b56c8ebc584c363774010a9bfe549a87126e61746',
-          'M/0'
+          'm->pub'
         );
       });
     })
 
-    wally.bip32_privkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpriv_0_0) {
-      wally.wally_base58_from_bytes(xpriv_0_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpriv) {
+    wally.bip32_privkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpriv_0) {
+      wally.wally_base58_from_bytes(xpriv_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpriv) {
         t.equal(
           base58_xpriv,
           'xprv9u4S6Taa3k3GxnaHfWzboKwLPPPHpDyDHdLGqDArBejguBuv6GkerLy6MtAeFfo9RDfZy22FWEc1ExEShuRGZJpgVgeVu5KZ5obWbV2R3D2',
-          'xpriv m/0/0'
+          'm/0'
         );
       });
     });
 
-    wally.bip32_pubkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpub_0_0) {
-      wally.wally_base58_from_bytes(xpub_0_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
+    wally.bip32_pubkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpub_0) {
+      wally.wally_base58_from_bytes(xpub_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
         t.equal(
           base58_xpub,
           'xpub683nVy7Tt7baBGekmYXcATt4wRDnDgh4erFsdbaTjzGfmzF4dp4uQ9HaDCdvSqctrsbxZey5wozKyyy2J3zhDDHU3UhW4uCFQp6bESv8ewQ',
-          'xpub M/0/0'
+          'M/0'
         );
       });
 
-      wally.bip32_pubkey_from_parent(xpub_0_0, 1, wally.BIP32_FLAG_KEY_PUBLIC).then(function (xpub_0_0_1) {
-        wally.wally_base58_from_bytes(xpub_0_0_1, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
+      wally.bip32_pubkey_from_parent(xpub_0, 1, wally.BIP32_FLAG_KEY_PUBLIC).then(function (xpub_0_1) {
+        wally.wally_base58_from_bytes(xpub_0_1, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
           t.equal(
             base58_xpub,
             'xpub6An6e2ai6kSDnnxJ3876JwfeigdQu9YNudcP7ayT828xDFzFQkP9oBoBNdvj7xDrDQd9TQDpzkLhM5L71rFDTmxMuzSvXwZKnLx56Es6MEg',
-            'xpub M/0/0/1'
+            'M/0/1'
           );
         });
       });

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -4,7 +4,7 @@ const EC_PUBLIC_KEY_LEN = 33;
 var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 test('BIP32 from seed + derivation', function(t) {
-  t.plan(7);
+  t.plan(6);
   wally.bip32_key_from_seed(Buffer.from(seed), 0x0488ADE4, 0).then(function(s) {
     wally.wally_base58_from_bytes(s, 1).then(function (s) {
       t.equal(
@@ -59,17 +59,6 @@ test('BIP32 from seed + derivation', function(t) {
             base58_xpub,
             'xpub6An6e2ai6kSDnnxJ3876JwfeigdQu9YNudcP7ayT828xDFzFQkP9oBoBNdvj7xDrDQd9TQDpzkLhM5L71rFDTmxMuzSvXwZKnLx56Es6MEg',
             'xpub M/0/0/1'
-          );
-        });
-
-        var version = Buffer.from('0014', 'hex');
-        wally.wally_hash160(xpub_0_0_1.slice(45, 78)).then((hash160) => {
-          return wally.wally_addr_segwit_from_bytes(Buffer.concat([version, Buffer.from(hash160)]),'tb',0);
-        }).then((addr) => {
-          t.equal(
-            addr,
-            'tb1q6pqwl5tyaluz8qtqky7x2cmxzqdr6gsyld4hrn',
-            'bech32: addr'
           );
         });
       });

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -1,13 +1,11 @@
 var wally = require('../wally');
 var test = require('tape');
+const EC_PUBLIC_KEY_LEN = 33;
+var seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 test('BIP32 from seed + derivation', function(t) {
-  t.plan(2);
-  var zeroes = [];
-  for (var i = 0; i < 16; ++i) {
-    zeroes.push(0);
-  }
-  wally.bip32_key_from_seed(Buffer.from(zeroes), 0x0488ADE4, 0).then(function(s) {
+  t.plan(7);
+  wally.bip32_key_from_seed(Buffer.from(seed), 0x0488ADE4, 0).then(function(s) {
     wally.wally_base58_from_bytes(s, 1).then(function (s) {
       t.equal(
         s,
@@ -16,6 +14,7 @@ test('BIP32 from seed + derivation', function(t) {
         'privkey'
       );
     });
+
     wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
       wally.wally_base58_from_bytes(pub, 1).then(function (s) {
         t.equal(
@@ -26,5 +25,74 @@ test('BIP32 from seed + derivation', function(t) {
         );
       });
     });
+
+    wally.wally_ec_public_key_from_private_key(s.slice(46, 78)).then(function(master_pubkey) {
+      t.equal(
+        Buffer.from(master_pubkey).toString('hex'),
+        '02be99138b48b430a8ee40bf8b56c8ebc584c363774010a9bfe549a87126e61746',
+        'M/0'
+      );
+    });
+
+    wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
+      wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
+        t.equal(
+          base58_xpriv,
+          'xprv9u4S6Taa3k3GxnaHfWzboKwLPPPHpDyDHdLGqDArBejguBuv6GkerLy6MtAeFfo9RDfZy22FWEc1ExEShuRGZJpgVgeVu5KZ5obWbV2R3D2',
+          'xpriv m/0/0'
+        );
+      });
+    });
+
+    wally.bip32_pubkey_from_parent(s, 0, 0).then(function (xpub_0_0) {
+      wally.wally_base58_from_bytes(xpub_0_0, 1).then(function (base58_xpub) {
+        t.equal(
+          base58_xpub,
+          'xpub683nVy7Tt7baBGekmYXcATt4wRDnDgh4erFsdbaTjzGfmzF4dp4uQ9HaDCdvSqctrsbxZey5wozKyyy2J3zhDDHU3UhW4uCFQp6bESv8ewQ',
+          'xpub M/0/0'
+        );
+      });
+
+      wally.bip32_pubkey_from_parent(xpub_0_0, 1, 1).then(function (xpub_0_0_1) {
+        wally.wally_base58_from_bytes(xpub_0_0_1, 1).then(function (base58_xpub) {
+          t.equal(
+            base58_xpub,
+            'xpub6An6e2ai6kSDnnxJ3876JwfeigdQu9YNudcP7ayT828xDFzFQkP9oBoBNdvj7xDrDQd9TQDpzkLhM5L71rFDTmxMuzSvXwZKnLx56Es6MEg',
+            'xpub M/0/0/1'
+          );
+        });
+
+        var version = Buffer.from('0014', 'hex');
+        wally.wally_hash160(xpub_0_0_1.slice(45, 78)).then((hash160) => {
+          return wally.wally_addr_segwit_from_bytes(Buffer.concat([version, Buffer.from(hash160)]),'tb',0);
+        }).then((addr) => {
+          t.equal(
+            addr,
+            'tb1q6pqwl5tyaluz8qtqky7x2cmxzqdr6gsyld4hrn',
+            'bech32: addr'
+          );
+        });
+      });
+    });
+  });
+});
+
+test('BIP32 from seed to address', function(t) {
+  t.plan(1);
+
+  wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
+    return wally.bip32_pubkey_from_parent(s, 0, 1);
+  }).then((xpubkey) => {
+    const pubkey = xpubkey.slice(45, 78);
+    return wally.wally_hash160(pubkey);
+  }).then((script) => {
+    const prefix = Buffer.from('eb', 'hex');
+    return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), 1);
+  }).then((address) => {
+    t.equal(
+      address,
+      '2dmvtD27wpRyLK79FsAidyS33uUogsYNC4U',
+      'address'
+    );
   });
 });

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -1,12 +1,12 @@
-var wally = require('../wally');
-var test = require('tape');
-const EC_PUBLIC_KEY_LEN = 33;
-var seed = Buffer.from('00000000000000000000000000000000', 'hex');
+const wally = require('../wally');
+const test = require('tape');
+const seed = Buffer.from('00000000000000000000000000000000', 'hex');
 
 test('BIP32 from seed + derivation', function(t) {
   t.plan(6);
-  wally.bip32_key_from_seed(Buffer.from(seed), 0x0488ADE4, 0).then(function(s) {
-    wally.wally_base58_from_bytes(s, 1).then(function (s) {
+
+  wally.bip32_key_from_seed(Buffer.from(seed), wally.BIP32_VER_MAIN_PRIVATE, wally.BIP32_FLAG_KEY_PRIVATE).then(function(s) {
+    wally.wally_base58_from_bytes(s, wally.BASE58_FLAG_CHECKSUM).then(function (s) {
       t.equal(
         s,
         ('xprv9s21ZrQH143K2JbpEjGU94NcdKSASB7LuXvJCTsxuENcGN1nVG7Q'+
@@ -15,8 +15,8 @@ test('BIP32 from seed + derivation', function(t) {
       );
     });
 
-    wally.bip32_pubkey_from_parent(s, 1, 0).then(function (pub) {
-      wally.wally_base58_from_bytes(pub, 1).then(function (s) {
+    wally.bip32_pubkey_from_parent(s, 1, wally.BIP32_FLAG_KEY_PRIVATE).then(function (pub) {
+      wally.wally_base58_from_bytes(pub, wally.BASE58_FLAG_CHECKSUM).then(function (s) {
         t.equal(
           s,
           ('xpub683nVy7Tt7baCKuqho7X5C7TGuskZAa4wQ5YEue2BxtYB6upN4Yg'+
@@ -36,8 +36,8 @@ test('BIP32 from seed + derivation', function(t) {
       });
     })
 
-    wally.bip32_privkey_from_parent(s, 0, 0).then(function (xpriv_0_0) {
-      wally.wally_base58_from_bytes(xpriv_0_0, 1).then(function (base58_xpriv) {
+    wally.bip32_privkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpriv_0_0) {
+      wally.wally_base58_from_bytes(xpriv_0_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpriv) {
         t.equal(
           base58_xpriv,
           'xprv9u4S6Taa3k3GxnaHfWzboKwLPPPHpDyDHdLGqDArBejguBuv6GkerLy6MtAeFfo9RDfZy22FWEc1ExEShuRGZJpgVgeVu5KZ5obWbV2R3D2',
@@ -46,8 +46,8 @@ test('BIP32 from seed + derivation', function(t) {
       });
     });
 
-    wally.bip32_pubkey_from_parent(s, 0, 0).then(function (xpub_0_0) {
-      wally.wally_base58_from_bytes(xpub_0_0, 1).then(function (base58_xpub) {
+    wally.bip32_pubkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PRIVATE).then(function (xpub_0_0) {
+      wally.wally_base58_from_bytes(xpub_0_0, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
         t.equal(
           base58_xpub,
           'xpub683nVy7Tt7baBGekmYXcATt4wRDnDgh4erFsdbaTjzGfmzF4dp4uQ9HaDCdvSqctrsbxZey5wozKyyy2J3zhDDHU3UhW4uCFQp6bESv8ewQ',
@@ -55,8 +55,8 @@ test('BIP32 from seed + derivation', function(t) {
         );
       });
 
-      wally.bip32_pubkey_from_parent(xpub_0_0, 1, 1).then(function (xpub_0_0_1) {
-        wally.wally_base58_from_bytes(xpub_0_0_1, 1).then(function (base58_xpub) {
+      wally.bip32_pubkey_from_parent(xpub_0_0, 1, wally.BIP32_FLAG_KEY_PUBLIC).then(function (xpub_0_0_1) {
+        wally.wally_base58_from_bytes(xpub_0_0_1, wally.BASE58_FLAG_CHECKSUM).then(function (base58_xpub) {
           t.equal(
             base58_xpub,
             'xpub6An6e2ai6kSDnnxJ3876JwfeigdQu9YNudcP7ayT828xDFzFQkP9oBoBNdvj7xDrDQd9TQDpzkLhM5L71rFDTmxMuzSvXwZKnLx56Es6MEg',
@@ -71,15 +71,15 @@ test('BIP32 from seed + derivation', function(t) {
 test('BIP32 from seed to address', function(t) {
   t.plan(1);
 
-  wally.bip32_key_from_seed(seed, 0x0488ADE4, 0).then(function(s) {
-    return wally.bip32_pubkey_from_parent(s, 0, 1);
+  wally.bip32_key_from_seed(seed, wally.BIP32_VER_MAIN_PRIVATE, wally.BIP32_FLAG_KEY_PRIVATE).then(function(s) {
+    return wally.bip32_pubkey_from_parent(s, 0, wally.BIP32_FLAG_KEY_PUBLIC);
   }).then((xpubkey) => {
     return wally.bip32_key_get_pub_key(xpubkey);
   }).then((pubkey) => {
     return wally.wally_hash160(pubkey);
   }).then((script) => {
     const prefix = Buffer.from('eb', 'hex');
-    return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), 1);
+    return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), wally.BASE58_FLAG_CHECKSUM);
   }).then((address) => {
     t.equal(
       address,

--- a/src/wrap_js/test/test_bip32.js
+++ b/src/wrap_js/test/test_bip32.js
@@ -78,8 +78,8 @@ test('BIP32 from seed to address', function(t) {
   }).then((pubkey) => {
     return wally.wally_hash160(pubkey);
   }).then((script) => {
-    const prefix = new Uint8Array([0xeb]);
-    return wally.wally_base58_from_bytes(Buffer.concat([prefix, script]), wally.BASE58_FLAG_CHECKSUM);
+    const prefix = Buffer.from('eb', 'hex');
+    return wally.wally_base58_from_bytes(Buffer.concat([prefix, new Buffer(script)]), wally.BASE58_FLAG_CHECKSUM);
   }).then((address) => {
     t.equal(
       address,

--- a/src/wrap_js/test/test_script.js
+++ b/src/wrap_js/test/test_script.js
@@ -1,0 +1,24 @@
+var wally = require('../wally');
+var test = require('tape');
+
+const EC_PUBLIC_KEY_LEN = 33;
+var pubkeys = [
+    '02ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e99',
+    '03afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f3'
+];
+
+test('Script', function(t) {
+    t.plan(1);
+
+    var pubkey_bytes = Buffer.from(pubkeys[0] + pubkeys[1], 'hex');
+    var redeem_script = '522102ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e992103afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f352ae';
+    
+    wally.wally_scriptpubkey_multisig_from_bytes(
+        pubkey_bytes,
+        2,
+        0,
+        (pubkey_bytes.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3
+    ).then((res) => {
+        t.equal(Buffer.from(res).toString('hex'), redeem_script);
+    });
+});

--- a/src/wrap_js/test/test_script.js
+++ b/src/wrap_js/test/test_script.js
@@ -12,7 +12,7 @@ test('Script', function(t) {
 
     var pubkey_bytes = Buffer.from(pubkeys[0] + pubkeys[1], 'hex');
     var redeem_script = '522102ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e992103afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f352ae';
-    
+
     wally.wally_scriptpubkey_multisig_from_bytes(
         pubkey_bytes,
         2,

--- a/src/wrap_js/test/test_script.js
+++ b/src/wrap_js/test/test_script.js
@@ -1,8 +1,7 @@
-var wally = require('../wally');
-var test = require('tape');
+const wally = require('../wally');
+const test = require('tape');
 
-const EC_PUBLIC_KEY_LEN = 33;
-var pubkeys = [
+const pubkeys = [
     '02ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e99',
     '03afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f3'
 ];
@@ -10,14 +9,14 @@ var pubkeys = [
 test('Script', function(t) {
     t.plan(1);
 
-    var pubkey_bytes = Buffer.from(pubkeys[0] + pubkeys[1], 'hex');
-    var redeem_script = '522102ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e992103afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f352ae';
+    const pubkey_bytes = Buffer.from(pubkeys[0] + pubkeys[1], 'hex');
+    const redeem_script = '522102ad4199d0c53b564b39798c4c064a6e6093abbb71d56cc153abf75a02f85c8e992103afeefeba0806711b6d3fc7c8b0b6a3eff5ea2ecf938aea1b6a093898097875f352ae';
 
     wally.wally_scriptpubkey_multisig_from_bytes(
         pubkey_bytes,
         2,
         0,
-        (pubkey_bytes.byteLength / EC_PUBLIC_KEY_LEN) * 34 + 3
+        (pubkey_bytes.byteLength / wally.EC_PUBLIC_KEY_LEN) * 34 + 3
     ).then((res) => {
         t.equal(Buffer.from(res).toString('hex'), redeem_script);
     });


### PR DESCRIPTION
This builds on top of https://github.com/ElementsProject/libwally-core/pull/85

adds on top:

- code deduplication
- use of constants
- fix derivation labels
- use bip32_key_get_pub_key & bip32_key_get_priv_key instead of slice
- it removes one of the cases/examples as the generated address doesn't seem redeemable https://github.com/ElementsProject/libwally-core/pull/85/files#diff-8256341e9d6126fcdf265c5326cdc72bR43
- moves the example to a test
- some white space/semicolon fixes/unnecessary imports
