### PR TITLE
Expose wally_confidential_addr_from_addr to nodejs

### DIFF
--- a/src/wrap_js/makewrappers/wrap.py
+++ b/src/wrap_js/makewrappers/wrap.py
@@ -162,6 +162,10 @@ FUNCS = [
 ]
 FUNCS_NODE = [
     # Assets:
+    ('wally_confidential_addr_from_addr', F([
+        'string[addr]', 'uint32_t[prefix]', 'const_bytes[pubkey]', 
+        'out_str_p'
+    ])),
     ('wally_asset_generator_from_bytes', F([
         'const_bytes[asset]', 'const_bytes[abf]', 'out_bytes_fixedsized'
     ], out_size='33')),


### PR DESCRIPTION
It would be useful to expose wally_confidential_addr_from_addr to nodejs.