### PR TITLE
Add functions to handle unique prefix mnemonics

### DIFF
--- a/src/mnemonic.h
+++ b/src/mnemonic.h
@@ -33,4 +33,20 @@ int mnemonic_to_bytes(
     size_t len,
     size_t *written);
 
+/**
+ * Convert a mnemonic representation into a block of bytes. Accepts unique prefixes of wordlist words.
+ *
+ * @w: List of words.
+ * @mnemonic: Mnemonic sentence to store.
+ * @bytes_out: Where to store the converted representation.
+ * @len: The length of @bytes_out in bytes.
+ * @written: Destination for the number of bytes written.
+ */
+int mnemonic_prefix_to_bytes(
+    const struct words *w,
+    const char *mnemonic,
+    unsigned char *bytes_out,
+    size_t len,
+    size_t *written);
+
 #endif /* LIBWALLY_MNEMONIC_H */

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -83,6 +83,24 @@ size_t wordlist_lookup_word(const struct words *w, const char *word)
     return found ? found - w->indices + 1u : 0u;
 }
 
+size_t wordlist_lookup_prefix(const struct words *w, const char *prefix)
+{
+    const size_t prefix_len = strlen(prefix);
+    size_t found = 0;
+
+    size_t i;
+    for (i = 0; i < w->len; ++i) {
+        if (!strncmp(prefix, w->indices[i], prefix_len)) {
+            if (found) {
+                return 0;  // prefix match is not unique
+            }
+            found = i + 1;
+        }
+    }
+
+    return found;
+}
+
 const char *wordlist_lookup_index(const struct words *w, size_t idx)
 {
     if (idx >= w->len)

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -46,6 +46,19 @@ size_t wordlist_lookup_word(
     const char *word);
 
 /**
+ * Find the unique word matching a given prefix in a wordlist.
+ *
+ * @w: Parsed list of words to look up in.
+ * @word: The prefix to look up.
+ *
+ * Returns 0 if not found OR not unique, idx + 1 otherwise.
+ * @see wordlist_init.
+ */
+size_t wordlist_lookup_prefix(
+    const struct words *w,
+    const char *prefix);
+
+/**
  * Return the Nth word in a wordlist.
  *
  * @w: Parsed list of words to look up in.


### PR DESCRIPTION
Common practice with bip39 mnemonics is to use unique four-character prefixes
of wordlist words. In some cases (e.g. "steel" storage devices) there is not
space to store more than four characters. So, enable users to enter unique
prefixes instead of whole words.

This is an alternative to #91 for fixing #89 . If you like the approach, I can add tests and so forth. Unfortunately I forgot that C doesn't have default parameters, which makes this slightly messier than it would have been in C++. I also couldn't take advantage of bsearch due to the interface, which is slightly annoying but shouldn't be a big deal (wordlists are very short, time to search them should be negligible.)