### PR TITLE
Add MacOS artefacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ src/swig_python/wallycore/__init__.py
 src/swig_python/wallycore/wallycore.egg-info
 tools/build-aux/m4/l*.m4
 tools/build-aux/test-driver
+tools/build-aux/*-e
+src/secp256k1/build-aux/*-e
 src/secp256k1/test-suite.log
 src/secp256k1/*.log
 src/secp256k1/*.trs
@@ -80,6 +82,9 @@ docs/source/crypto.rst
 docs/source/script.rst
 docs/source/transaction.rst
 .idea/
+
+# MacOS
+**/.DS_Store
 
 # Windows
 *.obj


### PR DESCRIPTION
MacOS has the annoying habit of putting `.DSStore` files everywhere Finder goes.

I also found that `make` produced two `.sh-e` files, so I added a filter for that:
```
src/secp256k1/build-aux/ltmain.sh-e
tools/build-aux/ltmain.sh-e
```