### PR TITLE
Derive P2PKH, P2WPKH  and P2SH-P2WPKH address from BIP32 key

### DIFF
--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -130,6 +130,20 @@ WALLY_CORE_API int wally_bip32_key_to_address(
     char **output);
 
 /**
+ * Create a native SegWit address corresponding to a BIP32 key.
+ *
+ * :param hdkey: The extended key to use.
+ * :param addr_family: Address family to generate, e.g. "bc" or "tb".
+ * :param flags: For future use. Must be 0.
+ * :param output: Destination for the resulting segwit native address string.
+ */
+WALLY_CORE_API int wally_bip32_key_to_addr_segwit(
+    const struct ext_key *hdkey,
+    const char *addr_family,
+    uint32_t flags,
+    char **output);
+
+/**
  * Create a P2PKH address corresponding to a private key in Wallet Import Format.
  *
  * :param wif: Private key in Wallet Import Format.

--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -7,11 +7,17 @@
 extern "C" {
 #endif
 
+struct ext_key;
+
 #define WALLY_WIF_FLAG_COMPRESSED 0x0   /** Corresponding public key compressed */
 #define WALLY_WIF_FLAG_UNCOMPRESSED 0x1 /** Corresponding public key uncompressed */
 
 #define WALLY_CA_PREFIX_LIQUID 0x0c /** Liquid v1 confidential address prefix */
 #define WALLY_CA_PREFIX_LIQUID_REGTEST 0x04 /** Liquid v1 confidential address prefix for regtest */
+
+#define WALLY_ADDRESS_TYPE_P2PKH 0x01       /** P2PKH address ("1...") */
+#define WALLY_ADDRESS_TYPE_P2SH_P2WPKH 0x02 /** P2SH-P2WPKH wrapped SegWit address ("3...") */
+#define WALLY_ADDRESS_TYPE_P2WPKH 0x04      /** P2WPKH native SegWit address ("bc1...)" */
 
 /**
  * Create a segwit native address from a v0 witness program.
@@ -106,6 +112,22 @@ WALLY_CORE_API int wally_wif_to_public_key(
     unsigned char *bytes_out,
     size_t len,
     size_t *written);
+
+/**
+ * Create a legacy or wrapped SegWit address corresponding to a BIP32 key.
+ *
+ * :param hdkey: The extended key to use.
+ * :param flags: ``WALLY_ADDRESS_TYPE_P2PKH`` for a legacy address, ``WALLY_ADDRESS_TYPE_P2SH_P2WPKH``
+ *| for P2SH-wrapped SegWit.
+ * :param version: Version byte to generate address, e.g. with Bitcoin: 0x00 for P2PKH,
+ *| 0x05 for P2SH_P2WPKH (0x6F and 0xC4 respectively for Testnet).
+ * :param output: Destination for the resulting address string.
+ */
+WALLY_CORE_API int wally_bip32_key_to_address(
+    const struct ext_key *hdkey,
+    uint32_t flags,
+    uint32_t version,
+    char **output);
 
 /**
  * Create a P2PKH address corresponding to a private key in Wallet Import Format.

--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -19,6 +19,11 @@ struct ext_key;
 #define WALLY_ADDRESS_TYPE_P2SH_P2WPKH 0x02 /** P2SH-P2WPKH wrapped SegWit address ("3...") */
 #define WALLY_ADDRESS_TYPE_P2WPKH 0x04      /** P2WPKH native SegWit address ("bc1...)" */
 
+#define WALLY_ADDRESS_VERSION_P2PKH_MAINNET 0x00 /** P2PKH address on mainnet */
+#define WALLY_ADDRESS_VERSION_P2PKH_TESTNET 0x6F /** P2PKH address on testnet */
+#define WALLY_ADDRESS_VERSION_P2SH_MAINNET 0x05 /** P2SH address on mainnet */
+#define WALLY_ADDRESS_VERSION_P2SH_TESTNET 0xC4 /** P2SH address on testnet */
+
 /**
  * Create a segwit native address from a v0 witness program.
  *
@@ -119,8 +124,8 @@ WALLY_CORE_API int wally_wif_to_public_key(
  * :param hdkey: The extended key to use.
  * :param flags: ``WALLY_ADDRESS_TYPE_P2PKH`` for a legacy address, ``WALLY_ADDRESS_TYPE_P2SH_P2WPKH``
  *| for P2SH-wrapped SegWit.
- * :param version: Version byte to generate address, e.g. with Bitcoin: 0x00 for P2PKH,
- *| 0x05 for P2SH_P2WPKH (0x6F and 0xC4 respectively for Testnet).
+ * :param version: Version byte to generate address, e.g. with Bitcoin: WALLY_ADDRESS_VERSION_P2PKH_MAINNET,
+ *| WALLY_ADDRESS_VERSION_P2PKH_TESTNET, WALLY_ADDRESS_VERSION_P2SH_MAINNET and WALLY_ADDRESS_VERSION_P2SH_TESTNET.
  * :param output: Destination for the resulting address string.
  */
 WALLY_CORE_API int wally_bip32_key_to_address(
@@ -148,7 +153,7 @@ WALLY_CORE_API int wally_bip32_key_to_addr_segwit(
  *
  * :param wif: Private key in Wallet Import Format.
  * :param prefix: Prefix byte to use, e.g. 0x80, 0xef.
- * :param version: Version byte to generate address, e.g. 0x00, 0x6f.
+ * :param version: Version byte to generate address, e.g. WALLY_ADDRESS_VERSION_P2PKH_MAINNET, WALLY_ADDRESS_VERSION_P2PKH_TESTNET.
  * :param output: Destination for the resulting address string.
  */
 WALLY_CORE_API int wally_wif_to_address(

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -166,6 +166,7 @@ endif # USE_SWIG_JAVA
 lib_LTLIBRARIES = libwallycore.la
 
 libwallycore_la_SOURCES = \
+    address.c \
     aes.c \
     base58.c \
     bip32.c \
@@ -241,6 +242,7 @@ endif
 check-local: $(SWIG_PYTHON_TEST_DEPS) $(SWIG_JAVA_TEST_DEPS)
 if SHARED_BUILD_ENABLED
 if RUN_PYTHON_TESTS
+	$(AM_V_at)$(PYTHON_TEST) test/test_address.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_aes.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_base58.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_bech32.py

--- a/src/address.c
+++ b/src/address.c
@@ -54,3 +54,20 @@ int wally_bip32_key_to_address(const struct ext_key *hdkey, uint32_t flags,
     wally_clear(address, sizeof(address));
     return ret;
 }
+
+int wally_bip32_key_to_addr_segwit(const struct ext_key *hdkey, const char *addr_family,
+                                   uint32_t flags, char **output)
+{
+    int ret;
+
+    // Witness program bytes, including the version and data push opcode.
+    unsigned char witness_program_bytes[HASH160_LEN + 2];
+    witness_program_bytes[0] = OP_0;
+    witness_program_bytes[1] = HASH160_LEN;
+
+    if (wally_hash160(hdkey->pub_key, sizeof(hdkey->pub_key), witness_program_bytes + 2, HASH160_LEN) != WALLY_OK)
+        return WALLY_EINVAL;
+
+    ret = wally_addr_segwit_from_bytes(witness_program_bytes, HASH160_LEN + 2, addr_family, flags, output);
+    return ret;
+}

--- a/src/address.c
+++ b/src/address.c
@@ -22,10 +22,10 @@ int wally_bip32_key_to_address(const struct ext_key *hdkey, uint32_t flags,
         return WALLY_EINVAL;
 
     // Catch known incorrect combinations of address type and version:
-    if ((flags & WALLY_ADDRESS_TYPE_P2PKH && version == 0x05) ||
-        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == 0x00) ||
-        (flags & WALLY_ADDRESS_TYPE_P2PKH && version == 0xC4) ||
-        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == 0x6F))
+    if ((flags & WALLY_ADDRESS_TYPE_P2PKH && version == WALLY_ADDRESS_VERSION_P2SH_MAINNET) ||
+        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == WALLY_ADDRESS_VERSION_P2PKH_MAINNET) ||
+        (flags & WALLY_ADDRESS_TYPE_P2PKH && version == WALLY_ADDRESS_VERSION_P2SH_TESTNET) ||
+        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == WALLY_ADDRESS_VERSION_P2PKH_TESTNET))
         return WALLY_EINVAL;
 
     if (flags == WALLY_ADDRESS_TYPE_P2PKH) {

--- a/src/address.c
+++ b/src/address.c
@@ -1,0 +1,56 @@
+#include "internal.h"
+#include "base58.h"
+#include "ccan/ccan/build_assert/build_assert.h"
+#include <include/wally_address.h>
+#include <include/wally_bip32.h>
+#include <include/wally_crypto.h>
+#include <include/wally_script.h>
+
+int wally_bip32_key_to_address(const struct ext_key *hdkey, uint32_t flags,
+                               uint32_t version, char **output)
+{
+    unsigned char address[HASH160_LEN + 1];
+    int ret;
+
+    if (output)
+        *output = NULL;
+
+    if (!hdkey || (version & ~0xff) || (flags & ~0xff) || !output)
+        return WALLY_EINVAL;
+
+    if (!(flags & (WALLY_ADDRESS_TYPE_P2PKH | WALLY_ADDRESS_TYPE_P2SH_P2WPKH)))
+        return WALLY_EINVAL;
+
+    // Catch known incorrect combinations of address type and version:
+    if ((flags & WALLY_ADDRESS_TYPE_P2PKH && version == 0x05) ||
+        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == 0x00) ||
+        (flags & WALLY_ADDRESS_TYPE_P2PKH && version == 0xC4) ||
+        (flags & WALLY_ADDRESS_TYPE_P2SH_P2WPKH && version == 0x6F))
+        return WALLY_EINVAL;
+
+    if (flags == WALLY_ADDRESS_TYPE_P2PKH) {
+        // pub_key_hash = ripemd160(sha256(pubkey)
+        address[0] = (unsigned char) version & 0xff;
+        if (wally_hash160(hdkey->pub_key, sizeof(hdkey->pub_key), address + 1, HASH160_LEN) != WALLY_OK)
+            return WALLY_EINVAL;
+    } else {
+        // redeem_script = SegWit version 0 + push(keyhash) = OP_0 + 0x20 + [key_hash]
+        // where key_hash = ripemd160(sha256(pubkey))
+        unsigned char redeem_script[HASH160_LEN + 2];
+        redeem_script[0] = OP_0;
+        redeem_script[1] = HASH160_LEN;
+
+        if (wally_hash160(hdkey->pub_key, sizeof(hdkey->pub_key), redeem_script + 2, HASH160_LEN) != WALLY_OK)
+            return WALLY_EINVAL;
+
+        // P2SH address = version (e.g. 0x05) + ripemd160(sha256(redeem_script))
+        address[0] = (unsigned char) version & 0xff;
+        if (wally_hash160(redeem_script, sizeof(redeem_script), address + 1, HASH160_LEN) != WALLY_OK)
+            return WALLY_EINVAL;
+    }
+
+    ret = wally_base58_from_bytes(address, sizeof(address), BASE58_FLAG_CHECKSUM, output);
+
+    wally_clear(address, sizeof(address));
+    return ret;
+}

--- a/src/swig_java/swig.i
+++ b/src/swig_java/swig.i
@@ -416,6 +416,7 @@ static jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t len)
 %returns_size_t(wally_base58_to_bytes);
 %returns_size_t(wally_base58_get_length);
 %returns_string(wally_bip32_key_to_address);
+%returns_string(wally_bip32_key_to_addr_segwit);
 %returns_string(wally_confidential_addr_to_addr);
 %returns_array_(wally_confidential_addr_to_ec_public_key, 3, 4, EC_PUBLIC_KEY_LEN);
 %returns_string(wally_confidential_addr_from_addr);

--- a/src/swig_java/swig.i
+++ b/src/swig_java/swig.i
@@ -415,6 +415,7 @@ static jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t len)
 %returns_string(wally_base58_from_bytes);
 %returns_size_t(wally_base58_to_bytes);
 %returns_size_t(wally_base58_get_length);
+%returns_string(wally_bip32_key_to_address);
 %returns_string(wally_confidential_addr_to_addr);
 %returns_array_(wally_confidential_addr_to_ec_public_key, 3, 4, EC_PUBLIC_KEY_LEN);
 %returns_string(wally_confidential_addr_from_addr);

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -74,5 +74,10 @@ class AddressTests(unittest.TestCase):
         ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2WPKH, VERSION_P2SH)
         self.assertEqual(ret, WALLY_EINVAL)
 
+        # Obtain native SegWit address (P2WPKH)
+        ret, out = wally_bip32_key_to_addr_segwit(key, utf8('bc'), 0)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(out, vec[path]['address_segwit'])
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -11,10 +11,10 @@ ADDRESS_TYPE_P2PKH       = 0x01
 ADDRESS_TYPE_P2SH_P2WPKH = 0x02
 ADDRESS_TYPE_P2WPKH      = 0x04
 
-VERSION_P2PKH_MAINNET = 0x00
-VERSION_P2PKH_TESTNET = 0x6F
-VERSION_P2SH_MAINNET = 0x05
-VERSION_P2SH_TESTNET = 0xC4
+ADDRESS_VERSION_P2PKH_MAINNET = 0x00
+ADDRESS_VERSION_P2PKH_TESTNET = 0x6F
+ADDRESS_VERSION_P2SH_MAINNET = 0x05
+ADDRESS_VERSION_P2SH_TESTNET = 0xC4
 
 NETWORK_BITCOIN_MAINNET = 0x01
 NETWORK_BITCOIN_TESTNET = 0x02
@@ -81,7 +81,7 @@ class AddressTests(unittest.TestCase):
         key = self.get_test_key(vec, path)
 
         # Address type flag is mandatory
-        version = VERSION_P2PKH_MAINNET if network == NETWORK_BITCOIN_MAINNET else VERSION_P2PKH_TESTNET
+        version = ADDRESS_VERSION_P2PKH_MAINNET if network == NETWORK_BITCOIN_MAINNET else ADDRESS_VERSION_P2PKH_TESTNET
         ret, out = wally_bip32_key_to_address(key, 0, version)
         self.assertEqual(ret, WALLY_EINVAL)
 
@@ -91,7 +91,7 @@ class AddressTests(unittest.TestCase):
         self.assertEqual(out, vec[path]['address_legacy'])
 
         # Obtain wrapped SegWit address (P2SH_P2WPKH)
-        version = VERSION_P2SH_MAINNET if network == NETWORK_BITCOIN_MAINNET else VERSION_P2SH_TESTNET
+        version = ADDRESS_VERSION_P2SH_MAINNET if network == NETWORK_BITCOIN_MAINNET else ADDRESS_VERSION_P2SH_TESTNET
         ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2SH_P2WPKH, version)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_p2sh_segwit'])

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import unittest
+from util import *
+
+VER_MAIN_PUBLIC = 0x0488B21E
+VER_TEST_PUBLIC = 0x043587CF
+
+FLAG_KEY_PUBLIC = 0x1
+
+ADDRESS_TYPE_P2PKH       = 0x01
+ADDRESS_TYPE_P2SH_P2WPKH = 0x02
+ADDRESS_TYPE_P2WPKH      = 0x04
+
+VERSION_P2PKH = 0x00
+VERSION_P2SH = 0x05
+
+# Vector from test_bip32.py. We only need an xpub to derive addresses.
+vec = {
+
+    'm/0H/1': {
+        # xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ
+        FLAG_KEY_PUBLIC:  '0488B21E025C1BD648000000012A7857'
+                          '631386BA23DACAC34180DD1983734E44'
+                          '4FDBF774041578E9B6ADB37C1903501E'
+                          '454BF00751F24B1B489AA925215D66AF'
+                          '2234E3891C3B21A52BEDB3CD711C6F6E2AF7',
+
+        "address_legacy": '1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj',
+
+        "address_p2sh_segwit": '3DymAvEWH38HuzHZ3VwLus673bNZnYwNXu',
+
+        "address_segwit": 'bc1qhm6697d9d2224vfyt8mj4kw03ncec7a7fdafvt'
+    }
+
+}
+
+class AddressTests(unittest.TestCase):
+
+    SERIALIZED_LEN = 4 + 1 + 4 + 4 + 32 + 33
+
+    def unserialize_key(self, buf, buf_len):
+        key_out = ext_key()
+        ret = bip32_key_unserialize(buf, buf_len, byref(key_out))
+        return ret, key_out
+
+    def get_test_key(self, vec, path):
+        buf, buf_len = make_cbuffer(vec[path][FLAG_KEY_PUBLIC])
+        ret, key_out = self.unserialize_key(buf, self.SERIALIZED_LEN)
+        self.assertEqual(ret, WALLY_OK)
+
+        return key_out
+
+    def test_address_vectors(self):
+        self.do_test_vector(vec, 'm/0H/1')
+
+    def do_test_vector(self, vec, path):
+        key = self.get_test_key(vec, path)
+
+        # Address type flag is mandatory
+        ret, out = wally_bip32_key_to_address(key, 0, VERSION_P2PKH)
+        self.assertEqual(ret, WALLY_EINVAL)
+
+        # Obtain legacy address (P2PKH)
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2PKH, VERSION_P2PKH)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(out, vec[path]['address_legacy'])
+
+        # Obtain wrapped SegWit address (P2SH_P2WPKH)
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2SH_P2WPKH, VERSION_P2SH)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(out, vec[path]['address_p2sh_segwit'])
+
+        # wally_bip32_key_to_address does not support bech32 native SegWit (P2WPKH)
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2WPKH, VERSION_P2SH)
+        self.assertEqual(ret, WALLY_EINVAL)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -11,8 +11,13 @@ ADDRESS_TYPE_P2PKH       = 0x01
 ADDRESS_TYPE_P2SH_P2WPKH = 0x02
 ADDRESS_TYPE_P2WPKH      = 0x04
 
-VERSION_P2PKH = 0x00
-VERSION_P2SH = 0x05
+VERSION_P2PKH_MAINNET = 0x00
+VERSION_P2PKH_TESTNET = 0x6F
+VERSION_P2SH_MAINNET = 0x05
+VERSION_P2SH_TESTNET = 0xC4
+
+NETWORK_BITCOIN_MAINNET = 0x01
+NETWORK_BITCOIN_TESTNET = 0x02
 
 # Vector from test_bip32.py. We only need an xpub to derive addresses.
 vec = {
@@ -29,7 +34,25 @@ vec = {
 
         "address_p2sh_segwit": '3DymAvEWH38HuzHZ3VwLus673bNZnYwNXu',
 
-        "address_segwit": 'bc1qhm6697d9d2224vfyt8mj4kw03ncec7a7fdafvt'
+        "address_segwit": 'bc1qhm6697d9d2224vfyt8mj4kw03ncec7a7fdafvt',
+    },
+
+    'm/1H/1': {
+        # tpubDApXh6cD2fZ7WjtgpHd8yrWyYaneiFuRZa7fVjMkgxsmC1QzoXW8cgx9zQFJ81Jx4deRGfRE7yXA9A3STsxXj4CKEZJHYgpMYikkas9DBTP
+        FLAG_KEY_PUBLIC:  '043587CF025C1BD648000000012A7857'
+                          '631386BA23DACAC34180DD1983734E44'
+                          '4FDBF774041578E9B6ADB37C1903501E'
+                          '454BF00751F24B1B489AA925215D66AF'
+                          '2234E3891C3B21A52BEDB3CD711C6F6E2AF7',
+
+        "address_legacy": 'mxvewdhKCenLkYgNa8irv1UM2omEWPMdEE',
+
+
+        "address_p2sh_segwit": '2N5XyEfAXtVde7mv6idZDXp5NFwajYEj9TD',
+
+
+        "address_segwit": 'tb1qhm6697d9d2224vfyt8mj4kw03ncec7a7rtx6hc',
+
     }
 
 }
@@ -51,31 +74,35 @@ class AddressTests(unittest.TestCase):
         return key_out
 
     def test_address_vectors(self):
-        self.do_test_vector(vec, 'm/0H/1')
+        self.do_test_vector(vec, 'm/0H/1', NETWORK_BITCOIN_MAINNET)
+        self.do_test_vector(vec, 'm/1H/1', NETWORK_BITCOIN_TESTNET) # Testnet
 
-    def do_test_vector(self, vec, path):
+    def do_test_vector(self, vec, path, network):
         key = self.get_test_key(vec, path)
 
         # Address type flag is mandatory
-        ret, out = wally_bip32_key_to_address(key, 0, VERSION_P2PKH)
+        version = VERSION_P2PKH_MAINNET if network == NETWORK_BITCOIN_MAINNET else VERSION_P2PKH_TESTNET
+        ret, out = wally_bip32_key_to_address(key, 0, version)
         self.assertEqual(ret, WALLY_EINVAL)
 
         # Obtain legacy address (P2PKH)
-        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2PKH, VERSION_P2PKH)
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2PKH, version)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_legacy'])
 
         # Obtain wrapped SegWit address (P2SH_P2WPKH)
-        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2SH_P2WPKH, VERSION_P2SH)
+        version = VERSION_P2SH_MAINNET if network == NETWORK_BITCOIN_MAINNET else VERSION_P2SH_TESTNET
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2SH_P2WPKH, version)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_p2sh_segwit'])
 
         # wally_bip32_key_to_address does not support bech32 native SegWit (P2WPKH)
-        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2WPKH, VERSION_P2SH)
+        ret, out = wally_bip32_key_to_address(key, ADDRESS_TYPE_P2WPKH, version)
         self.assertEqual(ret, WALLY_EINVAL)
 
         # Obtain native SegWit address (P2WPKH)
-        ret, out = wally_bip32_key_to_addr_segwit(key, utf8('bc'), 0)
+        bech32_prefix = 'bc' if network == NETWORK_BITCOIN_MAINNET else 'tb'
+        ret, out = wally_bip32_key_to_addr_segwit(key, utf8(bech32_prefix), 0)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_segwit'])
 

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -145,6 +145,7 @@ for f in (
     ('bip39_mnemonic_to_seed', c_int, [c_char_p, c_char_p, c_void_p, c_ulong, c_ulong_p]),
     ('wally_addr_segwit_from_bytes', c_int, [c_void_p, c_ulong, c_char_p, c_uint, c_char_p_p]),
     ('wally_addr_segwit_to_bytes', c_int, [c_void_p, c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
+    ('wally_bip32_key_to_address', c_int, [POINTER(ext_key), c_uint, c_uint, c_char_p_p]),
     ('wally_confidential_addr_from_addr', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_char_p_p]),
     ('wally_confidential_addr_to_addr', c_int, [c_char_p, c_uint, c_char_p_p]),
     ('wally_confidential_addr_to_ec_public_key', c_int, [c_char_p, c_uint, c_void_p, c_ulong]),

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -146,6 +146,7 @@ for f in (
     ('wally_addr_segwit_from_bytes', c_int, [c_void_p, c_ulong, c_char_p, c_uint, c_char_p_p]),
     ('wally_addr_segwit_to_bytes', c_int, [c_void_p, c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
     ('wally_bip32_key_to_address', c_int, [POINTER(ext_key), c_uint, c_uint, c_char_p_p]),
+    ('wally_bip32_key_to_addr_segwit', c_int, [POINTER(ext_key), c_char_p, c_uint, c_char_p_p]),
     ('wally_confidential_addr_from_addr', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_char_p_p]),
     ('wally_confidential_addr_to_addr', c_int, [c_char_p, c_uint, c_char_p_p]),
     ('wally_confidential_addr_to_ec_public_key', c_int, [c_char_p, c_uint, c_void_p, c_ulong]),

--- a/src/wrap_js/src/combined.c
+++ b/src/wrap_js/src/combined.c
@@ -1,5 +1,6 @@
 #define SECP256K1_BUILD 1
 #include "internal.c"
+#include "address.c"
 #include "aes.c"
 #include "base58.c"
 #include "bech32.c"


### PR DESCRIPTION
Introduces function to derive a legacy (P2PKH) or wrapped SegWit (P2SH-P2WPKH) address from a BIP32 key:

```c
int wally_bip32_key_to_address(const struct ext_key *hdkey, uint32_t flags,
                               uint32_t version, char **output)
```

Implements #102 except for native SegWit, which I'll add a separate function for.

I did not add `c++` headers in `wally.hpp`.

I added tests in Python, but not for Javascript, Swig Python and Swig Java.