### PR TITLE
Apply uncrustify

### DIFF
--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -865,7 +865,7 @@ WALLY_CORE_API int wally_tx_confidential_value_from_satoshi(
 WALLY_CORE_API int wally_tx_confidential_value_to_satoshi(
     const unsigned char *value,
     size_t value_len,
-    uint64_t* value_out);
+    uint64_t *value_out);
 
 /**
  * Create a Elements transaction for signing and return its hash.

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -168,10 +168,10 @@ int bip32_key_from_seed(const unsigned char *bytes, size_t bytes_len,
 
 #define ALLOC_KEY() \
     if (!output) \
-        return WALLY_EINVAL; \
+    return WALLY_EINVAL; \
     *output = wally_malloc(sizeof(struct ext_key)); \
     if (!*output) \
-        return WALLY_ENOMEM; \
+    return WALLY_ENOMEM; \
     wally_clear((void *)*output, sizeof(struct ext_key))
 
 int bip32_key_from_seed_alloc(const unsigned char *bytes, size_t bytes_len,
@@ -708,7 +708,7 @@ int bip32_key_get_priv_key(const struct ext_key *hdkey, unsigned char *bytes_out
 
 #define GET_I(name) \
     int bip32_key_get_ ## name(const struct ext_key *hdkey, size_t *written) { \
-        if (written) *written = 0; \
+        if (written) * written = 0; \
         if (!hdkey || !written) return WALLY_EINVAL; \
         *written = hdkey->name; \
         return WALLY_OK; \

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -24,7 +24,7 @@ static const unsigned char DUMMY_SIG[EC_SIGNATURE_DER_MAX_LEN + 1]; /* +1 for si
 /* Bytes of stack space to use to avoid allocations for tx serializing */
 #define TX_STACK_SIZE 2048
 
-#define TX_CHECK_OUTPUT if (!output) return WALLY_EINVAL; else *output = NULL
+#define TX_CHECK_OUTPUT if (!output) return WALLY_EINVAL; else * output = NULL
 #define TX_OUTPUT_ALLOC(typ) \
     *output = wally_malloc(sizeof(typ)); \
     if (!*output) return WALLY_ENOMEM; \
@@ -33,9 +33,9 @@ static const unsigned char DUMMY_SIG[EC_SIGNATURE_DER_MAX_LEN + 1]; /* +1 for si
 
 #define TX_COPY_ELSE_CLEAR(dst, src, siz) \
     if (src) \
-        memcpy(dst, src, siz); \
+    memcpy(dst, src, siz); \
     else \
-        wally_clear(dst, siz);
+    wally_clear(dst, siz);
 
 #define BYTES_VALID(p, len) ((p != NULL) == (len != 0))
 #define BYTES_INVALID(p, len) (!BYTES_VALID(p, len))
@@ -2731,7 +2731,7 @@ int wally_tx_confidential_value_from_satoshi(uint64_t satoshi,
 
 int wally_tx_confidential_value_to_satoshi(const unsigned char *value,
                                            size_t value_len,
-                                           uint64_t* value_out)
+                                           uint64_t *value_out)
 {
     if (!value || value_len != WALLY_TX_ASSET_CT_VALUE_UNBLIND_LEN || !value_out || value[0] != 0x1)
         return WALLY_EINVAL;
@@ -2879,7 +2879,7 @@ static int tx_getb_impl(const void *input,
                                        unsigned char *bytes_out, size_t len) { \
         size_t written; \
         if (len != siz) \
-            return WALLY_EINVAL; \
+        return WALLY_EINVAL; \
         return tx_getb_impl(input, input->name, siz, bytes_out, len, &written); \
     }
 
@@ -2906,7 +2906,7 @@ GET_TX_ARRAY(tx_input, entropy, SHA256_LEN)
 
 #define GET_TX_I(typ, name, outtyp) \
     int wally_ ## typ ## _get_ ## name(const struct wally_ ## typ *input, outtyp * written) { \
-        if (written) *written = 0; \
+        if (written) * written = 0; \
         if (!input || !written) return WALLY_EINVAL; \
         *written = input->name; \
         return WALLY_OK; \
@@ -3002,7 +3002,7 @@ static int tx_setb_impl(const unsigned char *bytes, size_t bytes_len,
     int wally_ ## typ ## _set_ ## name(struct wally_ ## typ *output, \
                                        const unsigned char *bytes, size_t siz) { \
         if (!is_valid_elements_tx_output(output) || BYTES_INVALID(bytes, siz)) \
-            return WALLY_EINVAL; \
+        return WALLY_EINVAL; \
         return tx_setb_impl(bytes, siz, &output->name, &output->name ## _len); \
     }
 
@@ -3010,7 +3010,7 @@ static int tx_setb_impl(const unsigned char *bytes, size_t bytes_len,
     int wally_ ## typ ## _set_ ## name(struct wally_ ## typ *output, \
                                        const unsigned char *bytes, size_t siz) { \
         if (!is_valid_elements_tx_output(output) || (siz && siz != n) || BYTES_INVALID(bytes, siz)) \
-            return WALLY_EINVAL; \
+        return WALLY_EINVAL; \
         return tx_setb_impl(bytes, siz, &output->name, &output->name ## _len); \
     }
 #endif /* BUILD_ELEMENTS */


### PR DESCRIPTION
Running `./tools/uncrustify` on my own pull request revealed some existing issues. Fixing those here.


It does leave a lot of unresolved issues, making the tool hard to use:

```sh
$ ./tools/uncrustify
tools/uncrustify.cfg:720: unknown symbol 'align_number_left'
Parsing: include/wally_address.h as language C-Header
parse_cleanup(440): pc->orig_line is 169, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_bip32.h as language C-Header
parse_cleanup(440): pc->orig_line is 263, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_bip38.h as language C-Header
parse_cleanup(440): pc->orig_line is 121, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_bip39.h as language C-Header
parse_cleanup(440): pc->orig_line is 121, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_core.h as language C-Header
parse_cleanup(440): pc->orig_line is 249, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_crypto.h as language C-Header
parse_cleanup(440): pc->orig_line is 454, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_elements.h as language C-Header
parse_cleanup(440): pc->orig_line is 130, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_script.h as language C-Header
parse_cleanup(440): pc->orig_line is 426, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: include/wally_transaction.h as language C-Header
parse_cleanup(440): pc->orig_line is 952, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: src/aes.c as language C
Parsing: src/base58.c as language C
Parsing: src/base58.h as language C-Header
Parsing: src/bech32.c as language C
Parsing: src/bip32.c as language C
parse_cleanup(440): pc->orig_line is 715, orig_col is 5, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is ELSE
parse_cleanup(447): File: src/bip32.c, orig_line is 715, orig_col is 5, Error: Unexpected '}' for 'IF', which was on line 712
Parsing: src/bip32_int.h as language C-Header
parse_cleanup(440): pc->orig_line is 21, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: src/bip38.c as language C
Parsing: src/bip39.c as language C
Parsing: src/ccan_config.h as language C-Header
Parsing: src/ctest/test_bech32.c as language C
Parsing: src/ctest/test_clear.c as language C
Parsing: src/ctest/test_elements_tx.c as language C
Parsing: src/ctest/test_tx.c as language C
Parsing: src/elements.c as language C
Parsing: src/hex.c as language C
Parsing: src/hmac.c as language C
Parsing: src/hmac.h as language C-Header
Parsing: src/internal.c as language C
Parsing: src/internal.h as language C-Header
Parsing: src/mnemonic.c as language C
Parsing: src/mnemonic.h as language C-Header
Parsing: src/pbkdf2.c as language C
Parsing: src/script.c as language C
Parsing: src/script.h as language C-Header
Parsing: src/script_int.h as language C-Header
parse_cleanup(440): pc->orig_line is 116, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: src/scrypt.c as language C
Parsing: src/sign.c as language C
Parsing: src/transaction.c as language C
parse_cleanup(440): pc->orig_line is 2913, orig_col is 5, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is ELSE
parse_cleanup(447): File: src/transaction.c, orig_line is 2913, orig_col is 5, Error: Unexpected '}' for 'IF', which was on line 2910
Parsing: src/transaction_int.h as language C-Header
parse_cleanup(440): pc->orig_line is 116, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(442): (frm.top().type + 1) is UNKNOWN
Parsing: src/wif.c as language C
Parsing: src/wordlist.c as language C
Parsing: src/wordlist.h as language C-Header
```