### PR TITLE
Parse address to scriptPubKey

### DIFF
--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -15,6 +15,9 @@ struct ext_key;
 #define WALLY_CA_PREFIX_LIQUID 0x0c /** Liquid v1 confidential address prefix */
 #define WALLY_CA_PREFIX_LIQUID_REGTEST 0x04 /** Liquid v1 confidential address prefix for regtest */
 
+#define WALLY_NETWORK_BITCOIN_MAINNET 0x01 /** Bitcoin mainnet */
+#define WALLY_NETWORK_BITCOIN_TESTNET 0x02 /** Bitcoin testnet */
+
 #define WALLY_ADDRESS_TYPE_P2PKH 0x01       /** P2PKH address ("1...") */
 #define WALLY_ADDRESS_TYPE_P2SH_P2WPKH 0x02 /** P2SH-P2WPKH wrapped SegWit address ("3...") */
 #define WALLY_ADDRESS_TYPE_P2WPKH 0x04      /** P2WPKH native SegWit address ("bc1...)" */
@@ -53,6 +56,22 @@ WALLY_CORE_API int wally_addr_segwit_from_bytes(
 WALLY_CORE_API int wally_addr_segwit_to_bytes(
     const char *addr,
     const char *addr_family,
+    uint32_t flags,
+    unsigned char *bytes_out,
+    size_t len,
+    size_t *written);
+
+/**
+ * Infer a scriptPubKey from an address.
+ *
+ * :param addr: Address to infer the scriptPubKey from.
+ * :param flags: Pass ``WALLY_NETWORK_BITCOIN_MAINNET`` or ``WALLY_NETWORK_BITCOIN_TESTNET``.
+ * :param bytes_out: Destination for the resulting scriptPubKey
+ * :param len: Length of ``bytes_out`` in bytes.
+ * :param written: Destination for the number of bytes written to ``bytes_out``.
+ */
+WALLY_CORE_API int wally_address_to_scriptpubkey(
+    const char *addr,
     uint32_t flags,
     unsigned char *bytes_out,
     size_t len,

--- a/src/address.c
+++ b/src/address.c
@@ -1,5 +1,6 @@
 #include "internal.h"
 #include "base58.h"
+#include <stdbool.h>
 #include "ccan/ccan/build_assert/build_assert.h"
 #include <include/wally_address.h>
 #include <include/wally_bip32.h>
@@ -70,4 +71,53 @@ int wally_bip32_key_to_addr_segwit(const struct ext_key *hdkey, const char *addr
 
     ret = wally_addr_segwit_from_bytes(witness_program_bytes, HASH160_LEN + 2, addr_family, flags, output);
     return ret;
+}
+
+static bool is_p2pkh(unsigned char version)
+{
+   return version == WALLY_ADDRESS_VERSION_P2PKH_MAINNET || version == WALLY_ADDRESS_VERSION_P2PKH_TESTNET;
+}
+
+static bool is_p2sh(unsigned char version)
+{
+   return version == WALLY_ADDRESS_VERSION_P2SH_MAINNET || version == WALLY_ADDRESS_VERSION_P2SH_TESTNET;
+}
+
+static bool is_mainnet(unsigned char version)
+{
+   return version == WALLY_ADDRESS_VERSION_P2PKH_MAINNET  || version == WALLY_ADDRESS_VERSION_P2SH_MAINNET;
+}
+
+int wally_address_to_scriptpubkey(const char *addr, uint32_t flags, unsigned char *bytes_out,
+                                  size_t len, size_t *written)
+{
+    uint32_t version;
+    unsigned char bytes_base58_decode[1 + HASH160_LEN + BASE58_CHECKSUM_LEN];
+    size_t written_base58_decode;
+
+    if (written)
+        *written = 0;
+
+    if (!(flags == WALLY_NETWORK_BITCOIN_MAINNET || flags == WALLY_NETWORK_BITCOIN_TESTNET))
+        return WALLY_EINVAL;
+
+    // This returns WALLY_OK even if addr is too long for bytes_base58_decode
+    if (wally_base58_to_bytes(addr, BASE58_FLAG_CHECKSUM, bytes_base58_decode, sizeof(bytes_base58_decode), &written_base58_decode) != WALLY_OK)
+        return WALLY_EINVAL;
+
+    if (written_base58_decode != HASH160_LEN + 1)
+        return WALLY_EINVAL;
+
+    version = bytes_base58_decode[0];
+    if ((is_mainnet(version) && flags & WALLY_NETWORK_BITCOIN_TESTNET) || (!is_mainnet(version) && flags & WALLY_NETWORK_BITCOIN_MAINNET))
+        return WALLY_EINVAL;
+
+    if (is_p2pkh(version)) {
+        return wally_scriptpubkey_p2pkh_from_bytes(bytes_base58_decode + 1, HASH160_LEN, 0, bytes_out, len, written);
+    } else if (is_p2sh(version)) {
+        return wally_scriptpubkey_p2sh_from_bytes(bytes_base58_decode + 1, HASH160_LEN, 0, bytes_out, len, written);
+    } else {
+        return WALLY_EINVAL;
+    }
+
 }

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -35,6 +35,9 @@ vec = {
         "address_p2sh_segwit": '3DymAvEWH38HuzHZ3VwLus673bNZnYwNXu',
 
         "address_segwit": 'bc1qhm6697d9d2224vfyt8mj4kw03ncec7a7fdafvt',
+
+        ## OP_0 [pub_key_hash]
+        'scriptpubkey_segwit': '0014bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe',
     },
 
     'm/1H/1': {
@@ -53,6 +56,8 @@ vec = {
 
         "address_segwit": 'tb1qhm6697d9d2224vfyt8mj4kw03ncec7a7rtx6hc',
 
+        ## OP_0 [pub_key_hash]
+        'scriptpubkey_segwit': '0014bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe',
     }
 
 }
@@ -105,6 +110,12 @@ class AddressTests(unittest.TestCase):
         ret, out = wally_bip32_key_to_addr_segwit(key, utf8(bech32_prefix), 0)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_segwit'])
+
+        # Parse native SegWit address (P2WPKH):
+        out, out_len = make_cbuffer('00' * (100))
+        ret, written = wally_addr_segwit_to_bytes(utf8(vec[path]['address_segwit']), utf8(bech32_prefix), 0, out, out_len)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(hexlify(out[0:written]), utf8(vec[path]['scriptpubkey_segwit']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -32,7 +32,13 @@ vec = {
 
         "address_legacy": '1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj',
 
+        # OP_DUP OP_HASH160 [pub_key_hash] OP_EQUALVERIFY OP_CHECKSIG
+        'scriptpubkey_legacy': '76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac',
+
         "address_p2sh_segwit": '3DymAvEWH38HuzHZ3VwLus673bNZnYwNXu',
+
+        # OP_HASH160 [script_hash] OP_EQUAL
+        'scriptpubkey_p2sh_segwit': 'a91486cc442a97817c245ce90ed0d31d6dbcde3841f987',
 
         "address_segwit": 'bc1qhm6697d9d2224vfyt8mj4kw03ncec7a7fdafvt',
 
@@ -50,9 +56,13 @@ vec = {
 
         "address_legacy": 'mxvewdhKCenLkYgNa8irv1UM2omEWPMdEE',
 
+        # OP_DUP OP_HASH160 [pub_key_hash] OP_EQUALVERIFY OP_CHECKSIG
+        'scriptpubkey_legacy': '76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac',
 
         "address_p2sh_segwit": '2N5XyEfAXtVde7mv6idZDXp5NFwajYEj9TD',
 
+        # OP_HASH160 [script_hash] OP_EQUAL
+        'scriptpubkey_p2sh_segwit': 'a91486cc442a97817c245ce90ed0d31d6dbcde3841f987',
 
         "address_segwit": 'tb1qhm6697d9d2224vfyt8mj4kw03ncec7a7rtx6hc',
 
@@ -110,6 +120,20 @@ class AddressTests(unittest.TestCase):
         ret, out = wally_bip32_key_to_addr_segwit(key, utf8(bech32_prefix), 0)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(out, vec[path]['address_segwit'])
+
+        # Parse legacy address (P2PKH):
+        out, out_len = make_cbuffer('00' * (25))
+        ret, written = wally_address_to_scriptpubkey(utf8(vec[path]['address_legacy']), network, out, out_len)
+
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(hexlify(out[0:written]), utf8(vec[path]['scriptpubkey_legacy']))
+
+        # Parse wrapped SegWit address (P2SH_P2WPKH):
+        out, out_len = make_cbuffer('00' * (25))
+        ret, written = wally_address_to_scriptpubkey(utf8(vec[path]['address_p2sh_segwit']), network, out, out_len)
+
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(hexlify(out[0:written]), utf8(vec[path]['scriptpubkey_p2sh_segwit']))
 
         # Parse native SegWit address (P2WPKH):
         out, out_len = make_cbuffer('00' * (100))

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -147,6 +147,7 @@ for f in (
     ('bip39_mnemonic_to_seed', c_int, [c_char_p, c_char_p, c_void_p, c_ulong, c_ulong_p]),
     ('wally_addr_segwit_from_bytes', c_int, [c_void_p, c_ulong, c_char_p, c_uint, c_char_p_p]),
     ('wally_addr_segwit_to_bytes', c_int, [c_void_p, c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
+    ('wally_address_to_scriptpubkey', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
     ('wally_bip32_key_to_address', c_int, [POINTER(ext_key), c_uint, c_uint, c_char_p_p]),
     ('wally_bip32_key_to_addr_segwit', c_int, [POINTER(ext_key), c_char_p, c_uint, c_char_p_p]),
     ('wally_confidential_addr_from_addr', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_char_p_p]),


### PR DESCRIPTION
My initial idea was to write a parser that can take either a base58 or bech32 address and return a `scriptPubKey`, with flags to constrain it to correct coin. However, to keep the change minimal, I'm using a approach that reuses `wally_addr_segwit_to_bytes` for bech32 and adds a new function for base58. A caller should either figure out themselves which address format they're dealing with, or simply try both functions. 

This PR adds `wally_address_to_scriptpubkey` to parse a base58 addresses (P2PKH and P2SH). It returns a `scriptPubKey` which can be used to create a transaction output.

A flag is used to set either Bitcoin mainnet or testnet. It then automatically figures out if this is a `P2PKH` or `P2SH` address. This approach requires additional `switch` cases to support other coins.

An alternative approach could be to add a `version` argument. The downside of that approach is that the caller needs to loop over all possible address versions they support, e.g. call with `0x00` and `0x05` to try if a given address is mainnet P2PKH or P2SH. Although that approach is more similar to other libwally functions that take a version argument, I don't find it very user friendly.

This PR also adds a test for the existing `wally_addr_segwit_to_bytes` which parses bech32 addresses and returns a `scriptPubKey`.

This PR builds on top of #102, so the first 3 commits should be reviewed there.
