### PR TITLE
Allow SegWit versions 0-16

### DIFF
--- a/src/bech32.c
+++ b/src/bech32.c
@@ -245,8 +245,7 @@ int wally_addr_segwit_to_bytes(const char *addr, const char *addr_family,
     if (flags || !addr_family || !addr || !bytes_out || !len || !written)
         return WALLY_EINVAL;
 
-    /* Only v0 witness programs are currently allowed */
-    if (!segwit_addr_decode(&witver, decoded, written, addr_family, addr) || witver != 0)
+    if (!segwit_addr_decode(&witver, decoded, written, addr_family, addr) || witver > 16)
         ret = WALLY_EINVAL;
     else
         ret = wally_witness_program_from_bytes(decoded, *written, flags, bytes_out, len, written);


### PR DESCRIPTION
BIP173 permits witness versions up to 16.

Sending to future native witness outputs will be standard in the 0.19 Bitcoin Core release: https://github.com/bitcoin/bitcoin/pull/15846