### PR TITLE
support empty(0-byte) witness stack item in clone_witness().

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -216,13 +216,11 @@ static struct wally_tx_witness_stack *clone_witness(
 
     if (ret == WALLY_OK) {
         for (i = 0; i < stack->num_items && ret == WALLY_OK; ++i) {
-            if (stack->items[i].witness) {
-                ret = wally_tx_witness_stack_set(result, i,
-                                                 stack->items[i].witness,
-                                                 stack->items[i].witness_len);
-                if (ret != WALLY_OK)
-                    wally_tx_witness_stack_free(result);
-            }
+            ret = wally_tx_witness_stack_set(result, i,
+                                             stack->items[i].witness,
+                                             stack->items[i].witness_len);
+            if (ret != WALLY_OK)
+                wally_tx_witness_stack_free(result);
         }
     }
     return ret == WALLY_OK ? result : NULL;


### PR DESCRIPTION
The clone_witness function should support 0 byte witness item.

Currently, wally_tx_witness_stack_set() is supported 0 byte witness item.
However, due to a null check in clone_witness(), wally_tx_set_input_witness() don't support 0 byte witness items.
(If it is add 0 byte witness item to witness stack on wally_tx_witness_stack_add(), and it's add witness stack to txin on wally_tx_set_input_witness(), 0 byte witness item disappears from the witness stack on txin.)

This fix removes unnecessary checks of the witness items from clone_witness().
The witness items to be set should be checked with wally_tx_witness_stack_set().

(Please excuse my poor English.)