### PR TITLE
configure: update pkgconfig version for next release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([libwallycore],[0.7.2])
+AC_INIT([libwallycore],[0.7.5])
 AC_CONFIG_AUX_DIR([tools/build-aux])
 AC_CONFIG_MACRO_DIR([tools/build-aux/m4])
 AC_CONFIG_SRCDIR([src/mnemonic.h])


### PR DESCRIPTION
I noticed the pkgconfig version was reporting 0.7.2 instead of 0.7.4
when packaging wallycore in nix. It is most likely because of this
version which was not updated.

Ideally we would have this auto-update somehow, but for now let's just
prepare it for the next release.

Signed-off-by: William Casarin <jb55@jb55.com>