### PR TITLE
support for blech32

### DIFF
--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -163,6 +163,54 @@ WALLY_CORE_API int wally_confidential_addr_from_addr(
     const unsigned char *pub_key,
     size_t pub_key_len,
     char **output);
+
+/**
+ * Extract the segwit native address from a confidential address.
+ *
+ * :param address: The blech32 encoded confidential address to extract the address from.
+ * :param confidential_addr_family: The confidential address family to generate.
+ * :param addr_family: The address family to generate.
+ * :param output: Destination for the resulting address string.
+ *|    The string returned should be freed using `wally_free_string`.
+ */
+WALLY_CORE_API int wally_confidential_addr_to_addr_segwit(
+    const char *address,
+    const char *confidential_addr_family,
+    const char *addr_family,
+    char **output);
+
+/**
+ * Extract the blinding public key from a segwit confidential address.
+ *
+ * :param address: The blech32 encoded confidential address to extract the public key from.
+ * :param confidential_addr_family: The confidential address prefix byte.
+ * :param bytes_out: Destination for the public key.
+ * :param len: The length of ``bytes_out`` in bytes. Must be ``EC_PUBLIC_KEY_LEN``.
+ */
+WALLY_CORE_API int wally_confidential_addr_segwit_to_ec_public_key(
+    const char *address,
+    const char *confidential_addr_family,
+    unsigned char *bytes_out,
+    size_t len);
+
+/**
+ * Create a confidential address from an segwit native and blinding public key.
+ *
+ * :param address: The bech32 encoded address to make confidential.
+ * :param addr_family: The address family to generate.
+ * :param confidential_addr_family: The confidential address family to generate.
+ * :param pub_key: The blinding public key to associate with ``address``.
+ * :param pub_key_len: The length of ``pub_key`` in bytes. Must be ``EC_PUBLIC_KEY_LEN``.
+ * :param output: Destination for the resulting address string.
+ *|    The string returned should be freed using `wally_free_string`.
+ */
+WALLY_CORE_API int wally_confidential_addr_from_addr_segwit(
+    const char *address,
+    const char *addr_family,
+    const char *confidential_addr_family,
+    const unsigned char *pub_key,
+    size_t pub_key_len,
+    char **output);
 #endif /* BUILD_ELEMENTS */
 
 #ifdef __cplusplus

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ libwallycore_la_SOURCES = \
     bip39.c \
     bech32.c \
     elements.c \
+    blech32.c \
     hex.c \
     hmac.c \
     internal.c \
@@ -233,6 +234,11 @@ noinst_PROGRAMS += test_elements_tx
 test_elements_tx_SOURCES = ctest/test_elements_tx.c
 test_elements_tx_CFLAGS = -I$(top_srcdir)/include $(AM_CFLAGS)
 test_elements_tx_LDADD = $(lib_LTLIBRARIES) @CTEST_EXTRA_STATIC@
+TESTS += test_blech32
+noinst_PROGRAMS += test_blech32
+test_blech32_SOURCES = ctest/test_blech32.c
+test_blech32_CFLAGS = -I$(top_srcdir)/include $(AM_CFLAGS)
+test_blech32_LDADD = $(lib_LTLIBRARIES) @CTEST_EXTRA_STATIC@
 endif
 
 check-local: $(SWIG_PYTHON_TEST_DEPS) $(SWIG_JAVA_TEST_DEPS)

--- a/src/blech32.c
+++ b/src/blech32.c
@@ -1,0 +1,311 @@
+/* Copyright (c) 2017 Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "internal.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <include/wally_address.h>
+#include <include/wally_script.h>
+#include <include/wally_crypto.h>
+#include "script.h"
+
+#ifdef BUILD_ELEMENTS
+
+static uint64_t blech32_polymod_step(uint64_t pre) {
+    uint8_t b = pre >> 55;
+    return ((pre & 0x7fffffffffffffULL) << 5) ^
+           (-((b >> 0) & 1) & 0x7d52fba40bd886ULL) ^
+           (-((b >> 1) & 1) & 0x5e8dbf1a03950cULL) ^
+           (-((b >> 2) & 1) & 0x1c3a3c74072a18ULL) ^
+           (-((b >> 3) & 1) & 0x385d72fa0e5139ULL) ^
+           (-((b >> 4) & 1) & 0x7093e5a608865bULL);
+}
+
+static const char *charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static const int8_t charset_rev[128] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+    1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+    1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+};
+
+#define WALLY_BLECH32_MAXLEN ((size_t) 1000)
+
+static int blech32_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len, size_t max_input_len) {
+    uint64_t chk = 1;
+    size_t i = 0;
+    while (hrp[i] != 0) {
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') return 0;
+        chk = blech32_polymod_step(chk) ^ (ch >> 5);
+        ++i;
+    }
+    if (i + 13 + data_len > max_input_len) return 0;
+    chk = blech32_polymod_step(chk);
+    while (*hrp != 0) {
+        chk = blech32_polymod_step(chk) ^ (*hrp & 0x1f);
+        *(output++) = *(hrp++);
+    }
+    *(output++) = '1';
+    for (i = 0; i < data_len; ++i) {
+        if (*data >> 5) return 0;
+        chk = blech32_polymod_step(chk) ^ (*data);
+        *(output++) = charset[*(data++)];
+    }
+    for (i = 0; i < 12; ++i) {
+        chk = blech32_polymod_step(chk);
+    }
+    chk ^= 1;
+    for (i = 0; i < 12; ++i) {
+        *(output++) = charset[(chk >> ((11 - i) * 5)) & 0x1f];
+    }
+    *output = 0;
+    return 1;
+}
+
+static int blech32_decode(char *hrp, uint8_t *data, size_t *data_len, const char *input, size_t max_input_len) {
+    uint64_t chk = 1;
+    size_t i;
+    size_t input_len = strlen(input);
+    size_t hrp_len;
+    int have_lower = 0, have_upper = 0;
+    if (input_len < 8 || input_len > max_input_len) {
+        return 0;
+    }
+    *data_len = 0;
+    while (*data_len < input_len && input[(input_len - 1) - *data_len] != '1') {
+        ++(*data_len);
+    }
+    if (1 + *data_len >= input_len || *data_len < 12) {
+        return 0;
+    }
+    hrp_len = input_len - (1 + *data_len);
+    *(data_len) -= 12;
+    for (i = 0; i < hrp_len; ++i) {
+        int ch = input[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+        if (ch >= 'a' && ch <= 'z') {
+            have_lower = 1;
+        } else if (ch >= 'A' && ch <= 'Z') {
+            have_upper = 1;
+            ch = (ch - 'A') + 'a';
+        }
+        hrp[i] = ch;
+        chk = blech32_polymod_step(chk) ^ (ch >> 5);
+    }
+    hrp[i] = 0;
+    chk = blech32_polymod_step(chk);
+    for (i = 0; i < hrp_len; ++i) {
+        chk = blech32_polymod_step(chk) ^ (input[i] & 0x1f);
+    }
+    ++i;
+    while (i < input_len) {
+        int v = (input[i] & 0x80) ? -1 : charset_rev[(int)input[i]];
+        if (input[i] >= 'a' && input[i] <= 'z') have_lower = 1;
+        if (input[i] >= 'A' && input[i] <= 'Z') have_upper = 1;
+        if (v == -1) {
+            return 0;
+        }
+        chk = blech32_polymod_step(chk) ^ v;
+        if (i + 12 < input_len) {
+            data[i - (1 + hrp_len)] = v;
+        }
+        ++i;
+    }
+    if (have_lower && have_upper) {
+        return 0;
+    }
+    return chk == 1;
+}
+
+static int convert_bits(uint8_t *out, size_t *outlen, int outbits, const uint8_t *in, size_t inlen, int inbits, int pad) {
+    uint32_t val = 0;
+    int bits = 0;
+    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
+    while (inlen--) {
+        val = (val << inbits) | *(in++);
+        bits += inbits;
+        while (bits >= outbits) {
+            bits -= outbits;
+            out[(*outlen)++] = (val >> bits) & maxv;
+        }
+    }
+    if (pad) {
+        if (bits) {
+            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
+        }
+    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
+        return 0;
+    }
+    return 1;
+}
+
+static int blech32_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {
+    uint8_t data[WALLY_BLECH32_MAXLEN];
+    size_t datalen = 0;
+    if (witver > 16) goto fail;
+    if (witver == 0 && witprog_len != 53 && witprog_len != 65) goto fail;
+    if (witprog_len < 2 || witprog_len > 65) goto fail;
+    data[0] = witver;
+    convert_bits(data + 1, &datalen, 5, witprog, witprog_len, 8, 1);
+    ++datalen;
+    return blech32_encode(output, hrp, data, datalen, WALLY_BLECH32_MAXLEN);
+fail:
+    wally_clear_2(data, sizeof(data), (void *)witprog, witprog_len);
+    return 0;
+}
+
+static int blech32_addr_decode(int *witver, uint8_t *witdata, size_t *witdata_len, const char *hrp, const char *addr) {
+    uint8_t data[WALLY_BLECH32_MAXLEN];
+    char hrp_actual[WALLY_BLECH32_MAXLEN];
+    size_t data_len;
+    if (!blech32_decode(hrp_actual, data, &data_len, addr, WALLY_BLECH32_MAXLEN)) goto fail;
+    if (data_len == 0 || data_len > (WALLY_BLECH32_MAXLEN - 4)) goto fail;
+    if (strncmp(hrp, hrp_actual, WALLY_BLECH32_MAXLEN - 5) != 0) goto fail;
+    if (data[0] > 16) goto fail;
+    *witdata_len = 0;
+    if (!convert_bits(witdata, witdata_len, 8, data + 1, data_len - 1, 5, 0)) goto fail;
+    if (*witdata_len < 2 || *witdata_len > 65) goto fail;
+    if (data[0] == 0 && *witdata_len != 53 && *witdata_len != 65) goto fail;
+    *witver = data[0];
+    return 1;
+fail:
+    wally_clear_2(data, sizeof(data), hrp_actual, sizeof(hrp_actual));
+    return 0;
+}
+
+int wally_confidential_addr_to_addr_segwit(
+    const char *address,
+    const char *confidential_addr_family,
+    const char *addr_family,
+    char **output)
+{
+    unsigned char buf[WALLY_BLECH32_MAXLEN];
+    unsigned char *hash_bytes_p = &buf[EC_PUBLIC_KEY_LEN - 2];
+    int witver = 0;
+    size_t written = 0;
+    int ret;
+
+    if (output)
+        *output = NULL;
+
+    if (!address || !output)
+        return WALLY_EINVAL;
+
+    if (!blech32_addr_decode(&witver, buf, &written, confidential_addr_family, address))
+        ret = WALLY_EINVAL;
+    else if (witver != 0 || (written != 53 && written != 65))
+        ret = WALLY_EINVAL;    /* Only v0 witness programs are currently allowed */
+    else {
+        written = written - EC_PUBLIC_KEY_LEN + 2;
+        hash_bytes_p[0] = (unsigned char) witver;
+        hash_bytes_p[1] = (unsigned char) (written - 2);
+        ret = wally_addr_segwit_from_bytes(hash_bytes_p, written,
+                                           addr_family, 0, output);
+    }
+
+    wally_clear(buf, sizeof(buf));
+    return ret;
+}
+
+int wally_confidential_addr_segwit_to_ec_public_key(
+    const char *address,
+    const char *confidential_addr_family,
+    unsigned char *bytes_out,
+    size_t len)
+{
+    unsigned char buf[WALLY_BLECH32_MAXLEN];
+    int witver = 0;
+    size_t written = 0;
+    int ret = WALLY_OK;
+
+    if (!address || !bytes_out || !confidential_addr_family || len != EC_PUBLIC_KEY_LEN)
+        return WALLY_EINVAL;
+
+    /* Only v0 witness programs are currently allowed */
+    if (!blech32_addr_decode(&witver, buf, &written, confidential_addr_family, address))
+        ret = WALLY_EINVAL;
+    else if (witver != 0 || (written != 53 && written != 65))
+        ret = WALLY_EINVAL;
+    else
+        memcpy(bytes_out, buf, EC_PUBLIC_KEY_LEN);
+
+    wally_clear(buf, sizeof(buf));
+    return ret;
+}
+
+int wally_confidential_addr_from_addr_segwit(
+    const char *address,
+    const char *addr_family,
+    const char *confidential_addr_family,
+    const unsigned char *pub_key,
+    size_t pub_key_len,
+    char **output)
+{
+    char result[WALLY_BLECH32_MAXLEN + 1];
+    unsigned char buf[EC_PUBLIC_KEY_LEN + SHA256_LEN];
+    unsigned char *hash_bytes_p = &buf[EC_PUBLIC_KEY_LEN - 2];
+    size_t written = SHA256_LEN + 2;
+    int ret;
+
+    if (output)
+        *output = NULL;
+
+    if (!address || !addr_family || !confidential_addr_family || !pub_key
+            || pub_key_len != EC_PUBLIC_KEY_LEN || !output
+            || strlen(confidential_addr_family) >= WALLY_BLECH32_MAXLEN)
+        return WALLY_EINVAL;
+
+    /* get v0 witness programs script */
+    ret = wally_addr_segwit_to_bytes(address, addr_family, 0,
+                                     hash_bytes_p, written, &written);
+    if (ret == WALLY_OK) {
+        if ((written != (HASH160_LEN + 2)) && (written != (SHA256_LEN + 2))) 
+            ret = WALLY_EINVAL;
+        else {
+            /* Copy the confidentialKey / v0 witness programs */
+            memcpy(buf, pub_key, pub_key_len);
+            written -= 2;   /* ignore witnessVersion & hashSize */
+            written += EC_PUBLIC_KEY_LEN;
+            if (!blech32_addr_encode(result, confidential_addr_family, 0, buf, written))
+                return WALLY_ERROR;
+
+            *output = wally_strdup(result);
+            ret = (*output) ? WALLY_OK : WALLY_ENOMEM;
+        }
+    }
+
+    wally_clear(buf, sizeof(buf));
+    wally_clear(result, sizeof(result));
+    return ret;
+}
+
+#endif /* BUILD_ELEMENTS */

--- a/src/ctest/test_blech32.c
+++ b/src/ctest/test_blech32.c
@@ -1,0 +1,218 @@
+#include "config.h"
+
+#include <wally_core.h>
+#include <wally_address.h>
+#include <wally_crypto.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+static const char *elements_bech32 = "ert1qu6ssk77c466kg3x9wd82dqkd9udddykyfykm9k";
+static const char *elements_confidential_key = "03a398eed59a2368563bbd2bc68a7ccdbbd6dcbf43b298edc810d22edb6d761800";
+static const char *elements_blech32 = "el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqpe4ppdaa3t44v3zv2u6w56pv6tc666fvgzaclqjnkz0sd";
+
+// OP_HASH160 29b1ec079a9c6a45a4e9ab38c3aa3e0ad3dc61f0 OP_EQUALVERIFY
+// 332a30b8b2753e64b1d0ebc951c057f0d9c29992d11118794c0fa1c6d2357ca6
+static const char *elements_witness_script = "0020332a30b8b2753e64b1d0ebc951c057f0d9c29992d11118794c0fa1c6d2357ca6";
+static const char *elements_script_bech32 = "ert1qxv4rpw9jw5lxfvwsa0y4rszh7rvu9xvj6yg3s72vp7sud5340jnquagp6g";
+static const char *elements_script_blech32 = "el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqqve2xzutyaf7vjcap67f28q90uxec2ve95g3rpu5crapcmfr2l9xl5jzazvcpysz";
+
+
+static bool check_confidential_addr_from_addr_segwit_pubkey(void)
+{
+    size_t written = 0;
+    unsigned char pub_key[EC_PUBLIC_KEY_LEN];
+    char* blech32 = NULL;
+    int ret;
+    bool is_success = false;
+
+    ret = wally_hex_to_bytes(elements_confidential_key,
+        pub_key, EC_PUBLIC_KEY_LEN, &written);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (written != EC_PUBLIC_KEY_LEN)
+        return false;
+
+    ret = wally_confidential_addr_from_addr_segwit(elements_bech32,
+            "ert", "el", pub_key, EC_PUBLIC_KEY_LEN, &blech32);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strncmp(blech32, elements_blech32, strlen(elements_blech32) + 1) == 0)
+        is_success = true;
+
+    wally_free_string(blech32);
+    return is_success;
+}
+
+static bool check_confidential_addr_from_addr_segwit_script(void)
+{
+    size_t written = 0;
+    unsigned char pub_key[EC_PUBLIC_KEY_LEN];
+    unsigned char witness_script[SHA256_LEN + 2];
+    char bech32_address[91];
+    char* blech32 = NULL;
+    char* bech32 = NULL;
+    int ret;
+    bool is_success = false;
+
+    ret = wally_hex_to_bytes(elements_confidential_key,
+        pub_key, EC_PUBLIC_KEY_LEN, &written);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (written != EC_PUBLIC_KEY_LEN)
+        return false;
+
+    ret = wally_hex_to_bytes(elements_witness_script,
+                    witness_script, SHA256_LEN + 2, &written);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (written != (SHA256_LEN + 2))
+        return false;
+
+    ret = wally_addr_segwit_from_bytes(witness_script, written,
+                                       "ert", 0, &bech32);
+    if (ret != WALLY_OK)
+        return false;
+
+    strcpy(bech32_address, bech32);
+    wally_free_string(bech32);
+
+    if (strcmp(bech32_address, elements_script_bech32) != 0)
+        return false;
+
+    ret = wally_confidential_addr_from_addr_segwit(bech32_address,
+            "ert", "el", pub_key, EC_PUBLIC_KEY_LEN, &blech32);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strncmp(blech32, elements_script_blech32, strlen(elements_script_blech32) + 1) == 0)
+        is_success = true;
+
+    wally_free_string(blech32);
+    return is_success;
+}
+
+static bool check_confidential_addr_to_addr_segwit_pubkey(void)
+{
+    char* bech32 = NULL;
+    int ret;
+    bool is_success = false;
+
+    ret = wally_confidential_addr_to_addr_segwit(elements_blech32,
+                                                 "el", "ert", &bech32);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strcmp(bech32, elements_bech32) == 0)
+        is_success = true;
+
+    wally_free_string(bech32);
+    return is_success;
+}
+
+static bool check_confidential_addr_to_addr_segwit_script(void)
+{
+    char* bech32 = NULL;
+    int ret;
+    bool is_success = false;
+
+    ret = wally_confidential_addr_to_addr_segwit(elements_script_blech32,
+                                                 "el", "ert", &bech32);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strcmp(bech32, elements_script_bech32) == 0)
+        is_success = true;
+
+    wally_free_string(bech32);
+    return is_success;
+}
+
+static bool check_confidential_addr_segwit_to_ec_public_key_pubkey(void)
+{
+    char* pub_key_str = NULL;
+    unsigned char pub_key[EC_PUBLIC_KEY_LEN];
+    int ret;
+    bool is_success = false;
+
+    ret = wally_confidential_addr_segwit_to_ec_public_key(
+                elements_blech32, "el", pub_key, EC_PUBLIC_KEY_LEN);
+    if (ret != WALLY_OK)
+        return false;
+
+    ret = wally_hex_from_bytes(pub_key, EC_PUBLIC_KEY_LEN, &pub_key_str);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strcmp(pub_key_str, elements_confidential_key) == 0)
+        is_success = true;
+
+    wally_free_string(pub_key_str);
+    return is_success;
+}
+
+static bool check_confidential_addr_segwit_to_ec_public_key_script(void)
+{
+    char* pub_key_str = NULL;
+    unsigned char pub_key[EC_PUBLIC_KEY_LEN];
+    int ret;
+    bool is_success = false;
+
+    ret = wally_confidential_addr_segwit_to_ec_public_key(
+                elements_script_blech32, "el", pub_key, EC_PUBLIC_KEY_LEN);
+    if (ret != WALLY_OK)
+        return false;
+
+    ret = wally_hex_from_bytes(pub_key, EC_PUBLIC_KEY_LEN, &pub_key_str);
+    if (ret != WALLY_OK)
+        return false;
+
+    if (strcmp(pub_key_str, elements_confidential_key) == 0)
+        is_success = true;
+
+    wally_free_string(pub_key_str);
+    return is_success;
+}
+
+    
+
+int main(void)
+{
+    bool tests_ok = true;
+
+    if (!check_confidential_addr_from_addr_segwit_pubkey()) {
+        printf("check_confidential_addr_from_addr_segwit(pubkey) test failed!\n");
+        tests_ok = false;
+    }
+
+    if (!check_confidential_addr_from_addr_segwit_script()) {
+        printf("check_confidential_addr_from_addr_segwit(script) test failed!\n");
+        tests_ok = false;
+    }
+
+    if (!check_confidential_addr_to_addr_segwit_pubkey()) {
+        printf("check_confidential_addr_to_addr_segwit(pubkey) test failed!\n");
+        tests_ok = false;
+    }
+
+    if (!check_confidential_addr_to_addr_segwit_script()) {
+        printf("check_confidential_addr_to_addr_segwit(script) test failed!\n");
+        tests_ok = false;
+    }
+
+    if (!check_confidential_addr_segwit_to_ec_public_key_pubkey()) {
+        printf("check_confidential_addr_segwit_to_ec_public_key(pubkey) test failed!\n");
+        tests_ok = false;
+    }
+
+    if (!check_confidential_addr_segwit_to_ec_public_key_script()) {
+        printf("check_confidential_addr_segwit_to_ec_public_key(script) test failed!\n");
+        tests_ok = false;
+    }
+
+    return tests_ok ? 0 : 1;
+}


### PR DESCRIPTION
Implements blech32, the confidential format of the bech32 address.

The following API has been added for segwit confidential address.
- wally_confidential_addr_to_addr_segwit
- wally_confidential_addr_from_addr_segwit
- wally_confidential_addr_segwit_to_ec_public_key

(My English isn't so good so feel free to ask me if there is anything unclear.)

Closes #97