### PR TITLE
bip32: add key_strip_private_key to the public api

### DIFF
--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -298,6 +298,16 @@ WALLY_CORE_API int bip32_key_from_base58_alloc(
     const char *base58,
     struct ext_key **output);
 
+/**
+ * Converts a private extended key to a public extended key. Afterwards, only public child extended
+ * keys can be derived, and only the public serialization can be created.
+ * If the provided key is already public, nothing will be done.
+ *
+ * :param hdkey: The extended key to covert.
+ */
+WALLY_CORE_API int bip32_key_strip_private_key(
+    struct ext_key *hdkey);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -735,6 +735,14 @@ int bip32_key_from_base58_alloc(const char *base58,
     return ret;
 }
 
+int bip32_key_strip_private_key(struct ext_key *hdkey)
+{
+    if (!hdkey)
+        return WALLY_EINVAL;
+    key_strip_private_key(hdkey);
+    return WALLY_OK;
+}
+
 #if defined (SWIG_JAVA_BUILD) || defined (SWIG_PYTHON_BUILD) || defined (SWIG_JAVASCRIPT_BUILD)
 
 /* Getters for ext_key values */

--- a/src/test/test_bip32.py
+++ b/src/test/test_bip32.py
@@ -374,6 +374,19 @@ class BIP32Tests(unittest.TestCase):
             self.assertEqual(bip32_key_serialize(key_out, flag, buf, buf_len), WALLY_OK)
             self.assertEqual(h(buf).upper(), exp_hex)
 
+    def test_strip_private_key(self):
+        self.assertEqual(bip32_key_strip_private_key(None), WALLY_EINVAL)
+
+        _, pub, priv = self.create_master_pub_priv()
+
+        self.assertEqual(priv.priv_key[0], FLAG_KEY_PRIVATE)
+        self.assertEqual(bip32_key_strip_private_key(priv), WALLY_OK)
+        self.assertEqual(priv.priv_key[0], FLAG_KEY_PUBLIC)
+        self.assertEqual(priv.priv_key[1:], [0] * 32)
+
+        self.assertEqual(bip32_key_strip_private_key(pub), WALLY_OK)
+        self.assertEqual(pub.priv_key[0], FLAG_KEY_PUBLIC)
+        self.assertEqual(pub.priv_key[1:], [0] * 32)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -200,6 +200,7 @@ for f in (
     ('bip32_key_to_base58', c_int, [POINTER(ext_key), c_uint, c_char_p_p]),
     ('bip32_key_from_base58', c_int, [c_char_p, POINTER(ext_key)]),
     ('bip32_key_from_base58_alloc', c_int, [c_char_p, POINTER(POINTER(ext_key))]),
+    ('bip32_key_strip_private_key', c_int, [POINTER(ext_key)]),
     ('bip38_raw_from_private_key', c_int, [c_void_p, c_ulong, c_void_p, c_ulong, c_uint, c_void_p, c_ulong]),
     ('bip38_from_private_key', c_int, [c_void_p, c_ulong, c_void_p, c_ulong, c_uint, c_char_p_p]),
     ('bip38_to_private_key', c_int, [c_char_p, c_void_p, c_ulong, c_uint, c_void_p, c_ulong]),


### PR DESCRIPTION
It is useful for when you want an xpub at a keypath like m/44'/0'/0'.