### PR TITLE
msvc build support.

### DIFF
--- a/src/ccan/ccan/base64/base64.h
+++ b/src/ccan/ccan/base64/base64.h
@@ -2,6 +2,8 @@
 #ifndef CCAN_BASE64_H
 #define CCAN_BASE64_H
 
+#include "config.h"
+#include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <sys/types.h>

--- a/src/wrap_js/windows_config/binding.gyp.elements_tmpl
+++ b/src/wrap_js/windows_config/binding.gyp.elements_tmpl
@@ -1,0 +1,37 @@
+{
+  "targets": [
+    {
+      "target_name": "deps",
+      "sources": [ "src/combined.c", "src/combined_ccan.c", "src/combined_ccan2.c" ],
+      "defines": [ "SWIG_JAVASCRIPT_BUILD", "HAVE_CONFIG_H", "ECMULT_WINDOW_SIZE=16", "BUILD_ELEMENTS" ],
+      "include_dirs": [ "<(platform_include_dirs)", "<(libwally_dir)", "<(libwally_dir)/src", "<(libwally_dir)/src/secp256k1", "<(libwally_dir)/src/secp256k1/src", "<(libwally_dir)/src/ccan" ],
+      "type": "static_library"
+    },
+    {
+      "target_name": "wallycore",
+      "dependencies": [ "deps" ],
+      "sources": [ "nodejs_wrap.cc" ],
+      "include_dirs": [ "<(platform_include_dirs)", "<(libwally_dir)/src", "<!(node -e \"require('nan')\")" ],
+      "defines": [ "SWIG_JAVASCRIPT_BUILD", "HAVE_CONFIG_H", "ECMULT_WINDOW_SIZE=16", "BUILD_ELEMENTS" ],
+    }
+  ],
+  "conditions": [
+    [ 'OS=="mac"', {
+      "xcode_settings": {
+        "CLANG_CXX_LIBRARY": "libc++"
+      }
+    }],
+    [ 'OS=="win"', {
+      "variables": {
+        "platform_include_dirs": "windows_config",
+        "libwally_dir": "<!(echo %LIBWALLY_DIR%)"
+      }
+    }],
+    [ 'OS!="win"', {
+      "variables": {
+        "platform_include_dirs": "",
+        "libwally_dir": "<!(echo $LIBWALLY_DIR)"
+      }
+    }]
+  ]
+}

--- a/src/wrap_js/windows_config/binding.gyp.tmpl
+++ b/src/wrap_js/windows_config/binding.gyp.tmpl
@@ -1,0 +1,37 @@
+{
+  "targets": [
+    {
+      "target_name": "deps",
+      "sources": [ "src/combined.c", "src/combined_ccan.c", "src/combined_ccan2.c" ],
+      "defines": [ "SWIG_JAVASCRIPT_BUILD", "HAVE_CONFIG_H", "ECMULT_WINDOW_SIZE=16" ],
+      "include_dirs": [ "<(platform_include_dirs)", "<(libwally_dir)", "<(libwally_dir)/src", "<(libwally_dir)/src/secp256k1", "<(libwally_dir)/src/secp256k1/src", "<(libwally_dir)/src/ccan" ],
+      "type": "static_library"
+    },
+    {
+      "target_name": "wallycore",
+      "dependencies": [ "deps" ],
+      "sources": [ "nodejs_wrap.cc" ],
+      "include_dirs": [ "<(platform_include_dirs)", "<(libwally_dir)/src", "<!(node -e \"require('nan')\")" ],
+      "defines": [ "SWIG_JAVASCRIPT_BUILD", "HAVE_CONFIG_H", "ECMULT_WINDOW_SIZE=16" ],
+    }
+  ],
+  "conditions": [
+    [ 'OS=="mac"', {
+      "xcode_settings": {
+        "CLANG_CXX_LIBRARY": "libc++"
+      }
+    }],
+    [ 'OS=="win"', {
+      "variables": {
+        "platform_include_dirs": "windows_config",
+        "libwally_dir": "<!(echo %LIBWALLY_DIR%)"
+      }
+    }],
+    [ 'OS!="win"', {
+      "variables": {
+        "platform_include_dirs": "",
+        "libwally_dir": "<!(echo $LIBWALLY_DIR)"
+      }
+    }]
+  ]
+}

--- a/src/wrap_js/windows_config/config.h
+++ b/src/wrap_js/windows_config/config.h
@@ -23,7 +23,9 @@
 #define HAVE_UNISTD_H 1
 #define STDC_HEADERS 1
 #define VERSION "0.6"
+#if (!defined(_SSIZE_T_DECLARED)) && (!defined(_ssize_t)) && (!defined(ssize_t))
 #define ssize_t long long
+#endif
 
 #define alignment_ok(p, n) ((size_t)(p) % (n) == 0)
 

--- a/src/wrap_js/windows_config/config.h
+++ b/src/wrap_js/windows_config/config.h
@@ -23,6 +23,7 @@
 #define HAVE_UNISTD_H 1
 #define STDC_HEADERS 1
 #define VERSION "0.6"
+#define ssize_t long long
 
 #define alignment_ok(p, n) ((size_t)(p) % (n) == 0)
 

--- a/tools/msvc/build.bat
+++ b/tools/msvc/build.bat
@@ -11,7 +11,13 @@ REM everything is being munged together for Windows as a hack it causes
 REM problems. Make a copy called hex_.c as a workaround.
 copy src\ccan\ccan\str\hex\hex.c src\ccan\ccan\str\hex\hex_.c
 
+if %ELEMENTS_BUILD% == "elements" (
+  set ELEMENTS_OPT=/DBUILD_ELEMENTS
+) else (
+  set ELEMENTS_OPT=
+)
+
 REM Compile everything (wally, ccan, libsecp256k) in one lump.
 REM Define USE_ECMULT_STATIC_PRECOMPUTATION  to pick up the
 REM ecmult_static_context.h file generated previously
-cl /DUSE_ECMULT_STATIC_PRECOMPUTATION /DWALLY_CORE_BUILD /DHAVE_CONFIG_H /DSECP256K1_BUILD /I%LIBWALLY_DIR%\src\wrap_js\windows_config /I%LIBWALLY_DIR% /I%LIBWALLY_DIR%\src /I%LIBWALLY_DIR%\include /I%LIBWALLY_DIR%\src\ccan /I%LIBWALLY_DIR%\src\secp256k1 /Zi /LD src/aes.c src/base58.c src/bip32.c src/bip38.c src/bip39.c src/ecdh.c src/elements.c src/hex.c src/hmac.c src/internal.c src/mnemonic.c src/pbkdf2.c src/script.c src/scrypt.c src/sign.c src/transaction.c src/wif.c src/wordlist.c src/ccan/ccan/crypto/ripemd160/ripemd160.c src/ccan/ccan/crypto/sha256/sha256.c src/ccan/ccan/crypto/sha512/sha512.c src\ccan\ccan\str\hex\hex_.c src/secp256k1/src/secp256k1.c /Fewally.dll
+cl /utf-8 /DUSE_ECMULT_STATIC_PRECOMPUTATION /DECMULT_WINDOW_SIZE=16 /DWALLY_CORE_BUILD %ELEMENTS_OPT% /DHAVE_CONFIG_H /DSECP256K1_BUILD /I%LIBWALLY_DIR%\src\wrap_js\windows_config /I%LIBWALLY_DIR% /I%LIBWALLY_DIR%\src /I%LIBWALLY_DIR%\include /I%LIBWALLY_DIR%\src\ccan /I%LIBWALLY_DIR%\src\ccan\base64 /I%LIBWALLY_DIR%\src\secp256k1 /Zi /LD src/aes.c src/base58.c src/bech32.c src/bip32.c src/bip38.c src/bip39.c src/blech32.c src/ecdh.c src/elements.c src/hex.c src/hmac.c src/internal.c src/mnemonic.c src/pbkdf2.c src/psbt.c src/script.c src/scrypt.c src/sign.c src/symmetric.c src/transaction.c src/wif.c src/wordlist.c src/ccan/ccan/crypto/ripemd160/ripemd160.c src/ccan/ccan/crypto/sha256/sha256.c src/ccan/ccan/crypto/sha512/sha512.c src/ccan/ccan/base64/base64.c src\ccan\ccan\str\hex\hex_.c src/secp256k1/src/secp256k1.c /Fewally.dll

--- a/tools/msvc/gen_ecmult_static_context.bat
+++ b/tools/msvc/gen_ecmult_static_context.bat
@@ -1,2 +1,2 @@
-cl /DWALLY_CORE_BUILD /DHAVE_CONFIG_H /DSECP256K1_BUILD /I%LIBWALLY_DIR%\src\wrap_js\windows_config /I%LIBWALLY_DIR%\ /I%LIBWALLY_DIR%\src /I%LIBWALLY_DIR%\include /I%LIBWALLY_DIR%\src\ccan /I%LIBWALLY_DIR%\src\secp256k1 /Zi %LIBWALLY_DIR%\src/secp256k1/src/gen_context.c /Fegen_context.exe
+cl /utf-8 /DWALLY_CORE_BUILD /DHAVE_CONFIG_H /DSECP256K1_BUILD /I%LIBWALLY_DIR%\src\wrap_js\windows_config /I%LIBWALLY_DIR%\ /I%LIBWALLY_DIR%\src /I%LIBWALLY_DIR%\include /I%LIBWALLY_DIR%\src\ccan /I%LIBWALLY_DIR%\src\secp256k1 /Zi %LIBWALLY_DIR%\src/secp256k1/src/gen_context.c /Fegen_context.exe
 gen_context.exe

--- a/tools/msvc/wallyjs.bat
+++ b/tools/msvc/wallyjs.bat
@@ -8,9 +8,15 @@ set LIBWALLY_DIR=%cd%
 call "%~dp0\gen_ecmult_static_context.bat" || echo ERRORGENCONTEXT && exit /b 1
 
 REM Create wrappers for wallyjs node module
+REM Elements build is 'set ELEMENTS_BUILD="elements"'.
 cd src
-python wrap_js/makewrappers/wrap.py wally Release
-python wrap_js/makewrappers/wrap.py nodejs Release
+python wrap_js/makewrappers/wrap.py wally Release %ELEMENTS_BUILD%
+python wrap_js/makewrappers/wrap.py nodejs Release %ELEMENTS_BUILD%
+if %ELEMENTS_BUILD% == "elements" (
+  copy /Y /B wrap_js\windows_config\binding.gyp.elements_tmpl wrap_js\binding.gyp /B
+) else (
+  copy /Y /B wrap_js\windows_config\binding.gyp.tmpl wrap_js\binding.gyp /B
+)
 
 REM Install wallyjs
 cd wrap_js

--- a/tools/msvc/wallyjs.bat
+++ b/tools/msvc/wallyjs.bat
@@ -12,7 +12,7 @@ REM Elements build is 'set ELEMENTS_BUILD="elements"'.
 cd src
 python wrap_js/makewrappers/wrap.py wally Release %ELEMENTS_BUILD%
 python wrap_js/makewrappers/wrap.py nodejs Release %ELEMENTS_BUILD%
-if %ELEMENTS_BUILD% == "elements" (
+if "%ELEMENTS_BUILD%" == "elements" (
   copy /Y /B wrap_js\windows_config\binding.gyp.elements_tmpl wrap_js\binding.gyp /B
 ) else (
   copy /Y /B wrap_js\windows_config\binding.gyp.tmpl wrap_js\binding.gyp /B


### PR DESCRIPTION
1. Repair Windows build errors due to ssize_t.
- base64.h: add config.h, stdint.h
- windows_config/config.h: add ssize_t define

2. Update msvc/build.bat, gen_ecmult_static_context.bat, and wallyjs.bat
- add target newer source code
- add UTF-8 option
- add define: ECMULT_WINDOW_SIZE
- add elements build selecting