### PR TITLE
Get bip32 fingerprint

### DIFF
--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -308,6 +308,19 @@ WALLY_CORE_API int bip32_key_from_base58_alloc(
 WALLY_CORE_API int bip32_key_strip_private_key(
     struct ext_key *hdkey);
 
+/**
+ * Get the BIP32 fingerprint for an extended key. Performs hash160 calculation
+ * if previously skipped with ``BIP32_FLAG_SKIP_HASH``.
+ *
+ * :param hdkey: The extended key.
+ * :param bytes_out: Destination for the fingerprint.
+ * :param len: Size of ``bytes_out`` in bytes. Must be ``FINGERPRINT_LEN``.
+ */
+WALLY_CORE_API int bip32_key_get_fingerprint(
+    struct ext_key *hdkey,
+    unsigned char *bytes_out,
+    size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/wally_core.h
+++ b/include/wally_core.h
@@ -28,6 +28,9 @@ extern "C" {
 #define WALLY_EINVAL -2 /** Invalid argument */
 #define WALLY_ENOMEM -3 /** malloc() failed */
 
+/** BIP32 fingerprint length */
+#define FINGERPRINT_LEN 4
+
 /**
  * Initialize wally.
  *

--- a/include/wally_psbt.h
+++ b/include/wally_psbt.h
@@ -36,8 +36,6 @@ struct wally_psbt_output;
 struct wally_psbt;
 #else
 
-#define FINGERPRINT_LEN 4
-
 /** Key origin data. Contains a BIP 32 fingerprint and the derivation path */
 struct wally_key_origin_info {
     unsigned char fingerprint[FINGERPRINT_LEN];

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -743,6 +743,25 @@ int bip32_key_strip_private_key(struct ext_key *hdkey)
     return WALLY_OK;
 }
 
+int bip32_key_get_fingerprint(struct ext_key *hdkey,
+                              unsigned char *bytes_out, size_t len)
+{
+    /* Validate our arguments and then the input key */
+    if (!hdkey ||
+        !key_is_valid(hdkey) ||
+        !bytes_out || len != FINGERPRINT_LEN)
+        return WALLY_EINVAL;
+
+    /* Derive hash160 if needed. */
+    if (mem_is_zero(hdkey->hash160, sizeof(hdkey->hash160))) {
+        key_compute_hash160(hdkey);
+    }
+
+    /* Fingerprint is first 32 bits of the key hash. */
+    memcpy(bytes_out, hdkey->hash160, FINGERPRINT_LEN);
+    return WALLY_OK;
+}
+
 #if defined (SWIG_JAVA_BUILD) || defined (SWIG_PYTHON_BUILD) || defined (SWIG_JAVASCRIPT_BUILD)
 
 /* Getters for ext_key values */

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -257,7 +257,7 @@ int bip32_key_serialize(const struct ext_key *hdkey, uint32_t flags,
     *out++ = hdkey->depth;
 
     /* Save the first 32 bits of the parent key (aka fingerprint) only */
-    out = copy_out(out, hdkey->parent160, sizeof(uint32_t));
+    out = copy_out(out, hdkey->parent160, FINGERPRINT_LEN);
 
     tmp32_be = cpu_to_be32(hdkey->child_num);
     out = copy_out(out, &tmp32_be, sizeof(tmp32_be));
@@ -305,7 +305,7 @@ int bip32_key_unserialize(const unsigned char *bytes, size_t bytes_len,
      * user will need to call bip32_key_set_parent() (FIXME: Implement)
      * later if they want it to be fully populated.
      */
-    bytes = copy_in(key_out->parent160, bytes, sizeof(uint32_t));
+    bytes = copy_in(key_out->parent160, bytes, FINGERPRINT_LEN);
     bytes = copy_in(&key_out->child_num, bytes, sizeof(key_out->child_num));
     key_out->child_num = be32_to_cpu(key_out->child_num);
     bytes = copy_in(key_out->chain_code, bytes, sizeof(key_out->chain_code));

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -201,6 +201,7 @@ for f in (
     ('bip32_key_from_base58', c_int, [c_char_p, POINTER(ext_key)]),
     ('bip32_key_from_base58_alloc', c_int, [c_char_p, POINTER(POINTER(ext_key))]),
     ('bip32_key_strip_private_key', c_int, [POINTER(ext_key)]),
+    ('bip32_key_get_fingerprint', c_int, [POINTER(ext_key), c_void_p, c_ulong]),
     ('bip38_raw_from_private_key', c_int, [c_void_p, c_ulong, c_void_p, c_ulong, c_uint, c_void_p, c_ulong]),
     ('bip38_from_private_key', c_int, [c_void_p, c_ulong, c_void_p, c_ulong, c_uint, c_char_p_p]),
     ('bip38_to_private_key', c_int, [c_char_p, c_void_p, c_ulong, c_uint, c_void_p, c_ulong]),


### PR DESCRIPTION
Adds a method `bip32_key_get_fingerprint` to get the fingerprint for a given key.

It's rather trivial, but it lets consumers of the library avoid touching `struct ext_key` internals. Particularly having access to the master fingerprint is quite useful, e.g. to compose output descriptors (#151) and to talk to a library like [HWI](https://github.com/bitcoin-core/HWI).