### PR TITLE
(wrap_js) Add a guard to an empty LocalBuffer

### DIFF
--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -32,13 +32,13 @@ static bool IsValid(const typename Nan::Maybe<T>& maybe)
 // Binary data is expected as objects supporting the JS Buffer interface
 struct LocalBuffer {
     LocalBuffer(Nan::NAN_METHOD_ARGS_TYPE info, int n, int& ret)
-        : mData(0), mLength(0)
+        : mData(0), mLength(0), mDummyData(0)
     {
         Init(info[n], ret);
     }
 
     LocalBuffer(const v8::Local<v8::Value>& obj, int& ret)
-        : mData(0), mLength(0)
+        : mData(0), mLength(0), mDummyData(0)
     {
         Init(obj, ret);
     }
@@ -55,10 +55,12 @@ struct LocalBuffer {
                 }
             }
         }
+        if (mData == 0 && mLength == 0)
+            mData = &mDummyData;  // Set a dummy if the buffer is empty
     }
 
     LocalBuffer(size_t len, int& ret)
-        : mData(0), mLength(0)
+        : mData(0), mLength(0), mDummyData(0)
     {
         if (ret != WALLY_OK)
             return; // Do nothing, caller will already throw
@@ -67,11 +69,14 @@ struct LocalBuffer {
             mData = (unsigned char*) node::Buffer::Data(mBuffer);
             mLength = len;
         }
+        if (mData == 0 && mLength == 0)
+            mData = &mDummyData;  // Set a dummy if the buffer is empty
     }
 
     LocalObject mBuffer;
     unsigned char *mData;
     size_t mLength;
+    unsigned char mDummyData;
 };
 
 struct LocalArray {

--- a/src/wrap_js/makewrappers/templates/nan.py
+++ b/src/wrap_js/makewrappers/templates/nan.py
@@ -52,11 +52,11 @@ struct LocalBuffer {
                 if (IsValid(mBuffer)) {
                     mData = (unsigned char*) node::Buffer::Data(mBuffer);
                     mLength = node::Buffer::Length(mBuffer);
+                    if (mData == 0 && mLength == 0)
+                        mData = &mDummyData;  // Set a dummy if the buffer is empty
                 }
             }
         }
-        if (mData == 0 && mLength == 0)
-            mData = &mDummyData;  // Set a dummy if the buffer is empty
     }
 
     LocalBuffer(size_t len, int& ret)
@@ -68,9 +68,9 @@ struct LocalBuffer {
         if (local.ToLocal(&mBuffer)) {
             mData = (unsigned char*) node::Buffer::Data(mBuffer);
             mLength = len;
+            if (mData == 0 && mLength == 0)
+                mData = &mDummyData;  // Set a dummy if the buffer is empty
         }
-        if (mData == 0 && mLength == 0)
-            mData = &mDummyData;  // Set a dummy if the buffer is empty
     }
 
     LocalObject mBuffer;


### PR DESCRIPTION
If an empty buffer is set to LocalBuffer, set a dummy empty buffer to `LocalBuffer::mData` .

`LocalBuffer::mData` is set by `node::Buffer::Data()` .
However, `node::Buffer::Data()` is an API that calls nodejs directly, and its behavior has changed in nodejs v13.3.0.
Currently, `node::Buffer::Data()` on nodejs v13.3.0 has get null pointer from empty LocalBuffer.

Therefore, set the pointer address of an empty buffer so that a null pointer is not passed.