### PR TITLE
PSBT: fix getting scriptPubKey for non-P2SH inputs

### DIFF
--- a/src/psbt.c
+++ b/src/psbt.c
@@ -2594,8 +2594,15 @@ int wally_sign_psbt(
             scriptcode = input->redeem_script;
             scriptcode_len = input->redeem_script_len;
         } else {
-            scriptcode = psbt->tx->outputs[txin->index].script;
-            scriptcode_len = psbt->tx->outputs[txin->index].script_len;
+            if (input->non_witness_utxo) {
+                scriptcode = input->non_witness_utxo->outputs[txin->index].script;
+                scriptcode_len = input->non_witness_utxo->outputs[txin->index].script_len;
+            } else if (input->witness_utxo) {
+                scriptcode = input->witness_utxo->script;
+                scriptcode_len = input->witness_utxo->script_len;
+            } else {
+                continue;
+            }
         }
 
         if (input->non_witness_utxo) {


### PR DESCRIPTION
I took me a while to find this issue, so I added two new error code `WALLY_ERROR_SCRIPTCODE_LEN` and `WALLY_ERROR_MATCH_WITNESS_PROGRAM_HASH` to make that a bit easier next time.

The current PSBT signing code, when spending from a non-p2sh output, tries to obtain the scriptPubKey from its own output (instead of the previous transaction's output):
https://github.com/ElementsProject/libwally-core/blob/dbb5e11a76fc4e09ad6381ce695f740bc536ed9b/src/psbt.c#L2595-L2596

This doesn't make any sense, and causes the following (mainnet) example PSBT to fail to sign (and fail with `WALLY_ERROR_MATCH_WITNESS_PROGRAM_HASH`):

```
Key (1 out of 2): KxDQjJwvLdNNGhsipGgmceWaPjRndZuaQB9B2tgdHsw5sQ8Rtqje

cHNidP8BAH0CAAAAAV/0Rj8kmS/ZB5NjsQvCKM1LTtovmhuQu2GITtz/XUFnAAAAAAD9////AqAPAAAAAAAAIgAg2SAanVpF/Lx6c7mjRV2xL95PrYeO1kq+yERNnuQ5oBYzAwAAAAAAABYAFID4k35Wktcj2ZmZXhX06u31MHSGAAAAAAABASuIEwAAAAAAACIAIPhgjm5bU3+PyBgusRPPQPVkuZz5nYcXDE8awlkHTuj9AQVHUiECEVsppbTC5ki7r8EARt8A6DEXEJY+/RWodTTGcN0OsPohA5MTyAqYRgEEpOmryG8fc9H6mC7LMXImnZF0Feau7iZ1Uq4iBgIRWymltMLmSLuvwQBG3wDoMRcQlj79Fah1NMZw3Q6w+hy9Fr7lMAAAgAAAAIAAAACAAgAAgAAAAAAAAAAAIgYDkxPICphGAQSk6avIbx9z0fqYLssxciadkXQV5q7uJnUcNEIZPjAAAIAAAACAAAAAgAIAAIAAAAAAAAAAAAABAUdSIQMROfTTVvMRvdrTpGn+pMYvCLB/78Bc/PK8qqIYwgg1diEDUb/gzEHWzqIxfhWictWQ+Osk5XiRlQCzWIzI+0xHd11SriICAxE59NNW8xG92tOkaf6kxi8IsH/vwFz88ryqohjCCDV2HL0WvuUwAACAAAAAgAAAAIACAACAAQAAAAIAAAAiAgNRv+DMQdbOojF+FaJy1ZD46yTleJGVALNYjMj7TEd3XRw0Qhk+MAAAgAAAAIAAAACAAgAAgAEAAAACAAAAAAA=
```

I don't feel highly confident about my fix, but at least it works for the above transaction (I haven't tried for a non-witness input). cc @achow101 