### PR TITLE
Add wally_scriptpubkey_to_address

### DIFF
--- a/include/wally_address.h
+++ b/include/wally_address.h
@@ -88,6 +88,22 @@ WALLY_CORE_API int wally_address_to_scriptpubkey(
     size_t *written);
 
 /**
+ * Infer address from a scriptPubKey. For SegWit addresses, use `wally_addr_segwit_from_bytes`
+ * instead. To find out if an address is SegWit, use `wally_scriptpubkey_get_type`.
+ *
+ * :param scriptpubkey: scriptPubKey bytes.
+ * :param scriptpubkey_len: Length of ``scriptpubkey`` in bytes.
+ * :param network: One of ``WALLY_NETWORK_BITCOIN_MAINNET``, ``WALLY_NETWORK_BITCOIN_TESTNET``,
+ *|    ``WALLY_NETWORK_LIQUID``, ``WALLY_NETWORK_LIQUID_REGTEST``.
+ * :param output: Destination for the resulting Base58 encoded address string.
+ */
+WALLY_CORE_API int wally_scriptpubkey_to_address(
+    const unsigned char *scriptpubkey,
+    size_t scriptpubkey_len,
+    uint32_t network,
+    char **output);
+
+/**
  * Convert a private key to Wallet Import Format.
  *
  * :param priv_key: Private key bytes.

--- a/src/test/test_address.py
+++ b/src/test/test_address.py
@@ -128,12 +128,22 @@ class AddressTests(unittest.TestCase):
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(hexlify(out[0:written]), utf8(vec[path]['scriptpubkey_legacy']))
 
+        # Get address for P2PKH scriptPubKey
+        ret, out = wally_scriptpubkey_to_address(out, written, network)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(out, vec[path]['address_legacy'])
+
         # Parse wrapped SegWit address (P2SH_P2WPKH):
         out, out_len = make_cbuffer('00' * (25))
         ret, written = wally_address_to_scriptpubkey(utf8(vec[path]['address_p2sh_segwit']), network, out, out_len)
 
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(hexlify(out[0:written]), utf8(vec[path]['scriptpubkey_p2sh_segwit']))
+
+        # Get address for P2SH scriptPubKey
+        ret, out = wally_scriptpubkey_to_address(out, written, network)
+        self.assertEqual(ret, WALLY_OK)
+        self.assertEqual(out, vec[path]['address_p2sh_segwit'])
 
         # Parse native SegWit address (P2WPKH):
         out, out_len = make_cbuffer('00' * (100))

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -218,6 +218,7 @@ for f in (
     ('wally_addr_segwit_from_bytes', c_int, [c_void_p, c_ulong, c_char_p, c_uint, c_char_p_p]),
     ('wally_addr_segwit_to_bytes', c_int, [c_void_p, c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
     ('wally_address_to_scriptpubkey', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_ulong_p]),
+    ('wally_scriptpubkey_to_address', c_int, [c_void_p, c_ulong, c_uint, c_char_p_p]),
     ('wally_bip32_key_to_address', c_int, [POINTER(ext_key), c_uint, c_uint, c_char_p_p]),
     ('wally_bip32_key_to_addr_segwit', c_int, [POINTER(ext_key), c_char_p, c_uint, c_char_p_p]),
     ('wally_confidential_addr_from_addr', c_int, [c_char_p, c_uint, c_void_p, c_ulong, c_char_p_p]),


### PR DESCRIPTION
Closes #118 

The new `wally_scriptpubkey_to_address` function could be expanded later to also work with SegWit, but I can't be bothered :-)