### PR TITLE
script: fail scriptpubkey_multisig_from_bytes on too short out buf

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -561,13 +561,8 @@ int wally_scriptpubkey_multisig_from_bytes(
     if (!bytes || !bytes_len || bytes_len % EC_PUBLIC_KEY_LEN ||
         n_pubkeys < 1 || n_pubkeys > 16 || threshold < 1 || threshold > 16 ||
         threshold > n_pubkeys || (flags & ~WALLY_SCRIPT_MULTISIG_SORTED) ||
-        !bytes_out || !written)
+        !bytes_out || len < script_len || !written)
         return WALLY_EINVAL;
-
-    if (len < script_len) {
-        *written = script_len;
-        return WALLY_OK;
-    }
 
     memcpy(pubkey_bytes, bytes, bytes_len);
     if (flags & WALLY_SCRIPT_MULTISIG_SORTED) {

--- a/src/test/test_script.py
+++ b/src/test/test_script.py
@@ -177,7 +177,7 @@ class ScriptTests(unittest.TestCase):
             short_out, short_out_len = make_cbuffer('00' * (script_len - 1))
             short_args = (args[0], args[1], args[2], args[3], short_out, short_out_len)
             ret = wally_scriptpubkey_multisig_from_bytes(*short_args)
-            self.assertEqual(ret, (WALLY_OK, script_len))
+            self.assertEqual(ret, (WALLY_EINVAL, 0))
 
     def test_scriptpubkey_csv_2of2_then_1_from_bytes(self):
         """Tests for creating csv 2of2 then 1 scriptPubKeys"""


### PR DESCRIPTION
I accidentally called wally_scriptpubkey_multisig_from_bytes with the
outbuffer size set to 0. To my surprise, the function returned
WALLY_OK, with the `written` var set to the expected script size. In
other words it looked like the full script has been written to the
output buffer successfully even though nothing has happened.

This should obviously fail instead.