### PR TITLE
Use absolute path to dynamic library on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please report bugs and submit patches to https://github.com/ElementsProject/libw
 Wally can currently be built for:
 - Linux
 - Android
-- OS X
+- macOS
 - iOS
 - Windows
 
@@ -34,6 +34,20 @@ $ ./tools/autogen.sh
 $ ./configure <options - see below>
 $ make
 $ make check
+```
+
+### Building on macOS
+
+Using homebrew,
+```
+$ brew install gnu-sed
+```
+
+If you wish to enable the SWIG interface, you
+will need install the Java JDK 8 or newer, and install SWIG:
+
+```
+$ brew install swig
 ```
 
 ### configure options

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -1,6 +1,6 @@
 from ctypes import *
 from binascii import hexlify, unhexlify
-from os.path import isfile
+from os.path import isfile, abspath
 from os import urandom
 import platform
 import sys
@@ -11,6 +11,9 @@ for depth in [0, 1, 2]:
     root_dir = '../' * depth
     if isfile(root_dir + 'src/.libs/libwallycore.' + SO_EXT):
         break
+
+if platform.system() == 'Darwin':
+    root_dir = abspath(root_dir) + '/'
 
 libwally = CDLL(root_dir + 'src/.libs/libwallycore.' + SO_EXT)
 


### PR DESCRIPTION
- make check was failing on macOS Catalina with the following error:

  File "/Users/phil/src/github.com/philippem/libwally-core/src/test/util.py", line 15, in <module>
    libwally = CDLL(root_dir + 'src/.libs/libwallycore.' + SO_EXT)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ctypes/__init__.py", line 366, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(../src/.libs/libwallycore.dylib, 6): no suitable image found.  Did find:
	file system relative paths not allowed in hardened programs