### PR TITLE
clone_bytes: set *dst to NULL if we are asked to clone a zero length value

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -157,8 +157,10 @@ static bool is_valid_elements_tx(const struct wally_tx *tx)
 
 bool clone_bytes(unsigned char **dst, const unsigned char *src, size_t len)
 {
-    if (!len)
+    if (!len) {
+	*dst = NULL;
         return true;
+    }
     *dst = wally_malloc(len);
     if (*dst)
         memcpy(*dst, src, len);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -158,7 +158,7 @@ static bool is_valid_elements_tx(const struct wally_tx *tx)
 bool clone_bytes(unsigned char **dst, const unsigned char *src, size_t len)
 {
     if (!len) {
-	*dst = NULL;
+        *dst = NULL;
         return true;
     }
     *dst = wally_malloc(len);


### PR DESCRIPTION
This fixes psbt: in many places it assumes this behavior.  Older code carefully initializes to NULL before calling clone_bytes, so it's not broken by this change, but it's deeply surprising to new authors!

In particular, valgrind noticed the unitialized var in line 1665 in psbt.c:

	if (input->final_script_sig) {

This is set in wally_psbt_input_set_final_script_sig:

    unsigned char *result_final_script_sig;

    if (!clone_bytes(&result_final_script_sig, final_script_sig, final_script_sig_len)) {
    ...
    input->final_script_sig = result_final_script_sig;

Surprise, input->final_script_sig is now random garbage from the stack.

PSBT assumes similar behavior in other places: it seems easiest to fix the clone_bytes footgun rather than change all the psbt code.

Reported-by: @niftynei
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>