### PR TITLE
psbt: pass in NULL for script if script_len == 0

### DIFF
--- a/src/psbt.c
+++ b/src/psbt.c
@@ -1120,7 +1120,7 @@ static int psbt_input_from_bytes(
             p += uint64_from_le_bytes(p, &amount);
             script_len_len = varint_from_bytes(p, &script_len);
             p += script_len_len;
-            ret = wally_tx_output_init_alloc(amount, p, script_len, &result->witness_utxo);
+            ret = wally_tx_output_init_alloc(amount, script_len ? p : NULL, script_len, &result->witness_utxo);
             if (ret != WALLY_OK) {
                 return ret;
             }


### PR DESCRIPTION
`wally_tx_output_init_alloc` will fail if the script_len == 0 but the
buffer passed in for the script is not NULL; consequently if
`script_len` is 0 we should pass in a NULL pointer for the script.