### PR TITLE
expose wally_tx_clone

### DIFF
--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -269,6 +269,15 @@ WALLY_CORE_API int wally_tx_init_alloc(
     size_t outputs_allocation_len,
     struct wally_tx **output);
 
+/* Clone a wally_tx
+ *
+ * :param tx: The transaction to clone.
+ * :param output: The destination to clone the transaction to.
+ */
+WALLY_CORE_API int wally_tx_clone(
+    struct wally_tx *tx,
+    struct wally_tx **output);
+
 /**
  * Add a transaction input to a transaction.
  *

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -3276,3 +3276,11 @@ fail:
     }
     return ret;
 }
+
+int wally_tx_clone(struct wally_tx *tx, struct wally_tx **output)
+{
+    if (!is_valid_tx(tx)) {
+        return WALLY_EINVAL;
+    }
+    return clone_tx(tx, output);
+}


### PR DESCRIPTION
make it easier for users of libwally to also clone tx's for their own nefarious ends.