### PR TITLE
wally_tx_to_bytes: don't return WALLY_OK if buffer is too short.

### DIFF
--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -442,6 +442,9 @@ WALLY_CORE_API int wally_tx_from_hex(
  * :param bytes_out: Destination for the serialized transaction.
  * :param len: Size of ``bytes_out`` in bytes.
  * :param written: Destination for the length of the serialized transaction.
+ *
+ * If len is not sufficient, WALLY_ENOMEM is returned and written will be
+ * set to the number of bytes required.
  */
 WALLY_CORE_API int wally_tx_to_bytes(
     const struct wally_tx *tx,


### PR DESCRIPTION
WALLY_ENOMEM is the most suitable (since WALLY_EINVAL can happen for many other reasons), but document it.

Having the call "succeed" without actually doing anything is very dangerous.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>