### PR TITLE
feat: add WALLY_DISABLE_OP_CODE guard

### DIFF
--- a/include/wally_script.h
+++ b/include/wally_script.h
@@ -37,6 +37,7 @@ extern "C" {
 #define WALLY_SCRIPT_MULTISIG_SORTED  0x8 /** Sort public keys (BIP67) */
 
 /* Script opcodes */
+#ifndef WALLY_DISABLE_OP_CODE
 #define OP_0 0x00
 #define OP_FALSE 0x00
 #define OP_PUSHDATA1 0x4c
@@ -164,6 +165,7 @@ extern "C" {
 #define OP_NOP10 0xb9
 
 #define OP_INVALIDOPCODE 0xff
+#endif  /* WALLY_DISABLE_OP_CODE */
 
 /**
  * Determine the type of a scriptPubkey script.


### PR DESCRIPTION
libwally-core defines OP_CODE using define.
Due to that, the name of OP_CODE cannot be defined in the library being used. (The macro overwrites everything)
The OP_CODE name is a special word in Bitcoin scripts, so we want to use the same name in our Bitcoin application or library. In that case, defining with define is not desirable.
As a countermeasure, we want to be able to suppress the OP_CODE definition of libwally-core in the application or library to be used. It does not affect the build of libwally-core.