### PR TITLE
fix: mnemonic memory leak.

### DIFF
--- a/src/mnemonic.c
+++ b/src/mnemonic.c
@@ -62,17 +62,19 @@ char *mnemonic_from_bytes(const struct words *w, const unsigned char *bytes, siz
 int mnemonic_to_bytes(const struct words *w, const char *mnemonic,
                       unsigned char *bytes_out, size_t len, size_t *written)
 {
-    struct words *mnemonic_w = wordlist_init(mnemonic);
+    struct words *mnemonic_w = NULL;
     size_t i;
 
     if (written)
         *written = 0;
 
-    if (!mnemonic_w)
-        return WALLY_ENOMEM;
-
     if (!w || !bytes_out || !len)
         return WALLY_EINVAL;
+
+    mnemonic_w = wordlist_init(mnemonic);
+
+    if (!mnemonic_w)
+        return WALLY_ENOMEM;
 
     if ((mnemonic_w->len * w->bits + 7u) / 8u > len)
         goto cleanup; /* Return the length we would have written */

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -20,6 +20,7 @@ static struct words *wordlist_alloc(const char *words, size_t len)
 {
     struct words *w = wally_malloc(sizeof(struct words));
     if (w) {
+        wally_clear(w, sizeof(*w));
         w->str = wally_strdup(words);
         if (w->str) {
             w->str_len = strlen(w->str);
@@ -29,7 +30,6 @@ static struct words *wordlist_alloc(const char *words, size_t len)
             if (w->indices)
                 return w;
         }
-        w->str_len = 0;
         wordlist_free(w);
     }
     return NULL;
@@ -92,9 +92,10 @@ const char *wordlist_lookup_index(const struct words *w, size_t idx)
 
 void wordlist_free(struct words *w)
 {
-    if (w && w->str_len) {
+    if (w) {
         if (w->str) {
-            wally_clear((void *)w->str,  w->str_len);
+            if (w->str_len)
+                wally_clear((void *)w->str,  w->str_len);
             wally_free((void *)w->str);
         }
         if (w->indices)


### PR DESCRIPTION
A memory leak was found during a memory leak test in a library that uses libwally-core.
The outline of the modification is as follows.

src/wordlist.c: wordlist_free
  - if check `w->str_len != 0`, no call `wally_free(w)` case.
  - remove top `w->str_len != 0` check, and if `w->str_len != 0` call wally_clear before wally_free.

src/wordlist.c: wordlist_alloc
  - remove `w->str_len = 0;`
  - instead of, insert wally_clear(w, sizeof(*w)). (for struct initializing)

src/mnemonic.c: mnemonic_to_bytes
  - Move the call to `wordlist_init`.
    - because `if (!w || !bytes_out || !len)` case is not call wordlist_free(mnemonic_w).