### PR TITLE
psbt: allow partial transactions.

### DIFF
--- a/src/psbt.c
+++ b/src/psbt.c
@@ -2076,7 +2076,7 @@ int wally_psbt_to_bytes(
         return ret;
     }
     p += varint_to_bytes(tx_len, p);
-    ret = wally_tx_to_bytes(psbt->tx, 0, p, end - p, &tx_len);
+    ret = wally_partial_tx_to_bytes(psbt->tx, 0, p, end - p, true, &tx_len);
     if (ret != WALLY_OK) {
         return ret;
     }

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -1972,7 +1972,8 @@ static int tx_to_bytes(const struct wally_tx *tx,
                        uint32_t flags,
                        unsigned char *bytes_out, size_t len,
                        size_t *written,
-                       bool is_elements)
+                       bool is_elements,
+                       bool partial_ok)
 {
     size_t n, i, j, witness_count;
     const bool anyonecanpay = opts && opts->sighash & WALLY_SIGHASH_ANYONECANPAY;
@@ -1983,9 +1984,12 @@ static int tx_to_bytes(const struct wally_tx *tx,
     if (written)
         *written = 0;
 
-    if (!is_valid_tx(tx) || !tx->num_inputs || !tx->num_outputs ||
+    if (!is_valid_tx(tx) ||
         (flags & ~WALLY_TX_FLAG_USE_WITNESS) || !bytes_out || !written ||
         tx_get_length(tx, opts, flags, &n, is_elements) != WALLY_OK)
+        return WALLY_EINVAL;
+
+    if (!partial_ok && (!tx->num_inputs || !tx->num_outputs))
         return WALLY_EINVAL;
 
     if (opts && (flags & WALLY_TX_FLAG_USE_WITNESS))
@@ -2138,9 +2142,10 @@ static int tx_to_bytes(const struct wally_tx *tx,
     return WALLY_OK;
 }
 
-int wally_tx_to_bytes(const struct wally_tx *tx, uint32_t flags,
-                      unsigned char *bytes_out, size_t len,
-                      size_t *written)
+int wally_partial_tx_to_bytes(const struct wally_tx *tx, uint32_t flags,
+                              unsigned char *bytes_out, size_t len,
+                              bool partial_ok,
+                              size_t *written)
 {
     size_t is_elements = 0;
 
@@ -2148,7 +2153,16 @@ int wally_tx_to_bytes(const struct wally_tx *tx, uint32_t flags,
     if (wally_tx_is_elements(tx, &is_elements) != WALLY_OK)
         return WALLY_EINVAL;
 #endif
-    return tx_to_bytes(tx, NULL, flags, bytes_out, len, written, is_elements);
+    return tx_to_bytes(tx, NULL, flags, bytes_out, len, written, is_elements,
+                       partial_ok);
+}
+
+
+int wally_tx_to_bytes(const struct wally_tx *tx, uint32_t flags,
+                      unsigned char *bytes_out, size_t len,
+                      size_t *written)
+{
+    return wally_partial_tx_to_bytes(tx, flags, bytes_out, len, false, written);
 }
 
 static int tx_to_hex(const struct wally_tx *tx, uint32_t flags,

--- a/src/transaction_shared.h
+++ b/src/transaction_shared.h
@@ -20,6 +20,10 @@ int analyze_tx(const unsigned char *bytes, size_t bytes_len,
 struct wally_tx_witness_stack *clone_witness(
     const struct wally_tx_witness_stack *stack);
 int clone_tx(struct wally_tx *tx, struct wally_tx **output);
+int wally_partial_tx_to_bytes(const struct wally_tx *tx, uint32_t flags,
+                              unsigned char *bytes_out, size_t len,
+                              bool partial_ok,
+                              size_t *written);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
During PSBT preparation, it can reasonably contain unfinished transactions.
In particular, we didn't allow marshalling of zero-output transactions.

Fixes: #205 