### PR TITLE
tests: enable non swig elements tests even when swig not enabled

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,7 +262,6 @@ if RUN_PYTHON_TESTS
 	$(AM_V_at)$(PYTHON_TEST) test/test_bip38.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_bip39.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_ecdh.py
-	$(AM_V_at)$(PYTHON_TEST) test/test_elements.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_hash.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_hex.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_hmac.py
@@ -275,6 +274,12 @@ if RUN_PYTHON_TESTS
 	$(AM_V_at)$(PYTHON_TEST) test/test_transaction.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_wif.py
 	$(AM_V_at)$(PYTHON_TEST) test/test_wordlist.py
+if BUILD_ELEMENTS
+	$(AM_V_at)$(PYTHON_TEST) test/test_confidential_addr.py
+	$(AM_V_at)$(PYTHON_TEST) test/test_pegin.py
+	$(AM_V_at)$(PYTHON_TEST) test/test_pegout.py
+	$(AM_V_at)$(PYTHON_TEST) test/test_elements.py
+endif
 if USE_SWIG_PYTHON
 	$(AM_V_at)$(PYTHON_SWIGTEST) swig_python/contrib/address.py
 	$(AM_V_at)$(PYTHON_SWIGTEST) swig_python/contrib/bip32.py
@@ -282,9 +287,6 @@ if USE_SWIG_PYTHON
 	$(AM_V_at)$(PYTHON_SWIGTEST) swig_python/contrib/sha.py
 	$(AM_V_at)$(PYTHON_SWIGTEST) swig_python/contrib/tx.py
 if BUILD_ELEMENTS
-	$(AM_V_at)$(PYTHON_TEST) test/test_confidential_addr.py
-	$(AM_V_at)$(PYTHON_TEST) test/test_pegin.py
-	$(AM_V_at)$(PYTHON_TEST) test/test_pegout.py
 	$(AM_V_at)$(PYTHON_SWIGTEST) swig_python/contrib/elements_tx.py
 	$(AM_V_at)$(PYTHON_SWIGTEST) pyexample/liquid/receive-send.py
 endif


### PR DESCRIPTION
too many if nests meant that the build_elements tests would only run if
both elements + swig_python were enabled. here we split this into two
sections, where non-swig build_elements tests will run iff build_elements is
flagged.