### PR TITLE
bip32: Don't call privkey_tweak_add by empty tweakSum

### DIFF
--- a/src/bip32.c
+++ b/src/bip32.c
@@ -337,6 +337,23 @@ int bip32_key_unserialize_alloc(const unsigned char *bytes, size_t bytes_len,
     return ret;
 }
 
+#ifdef BUILD_ELEMENTS
+static int bip32_privkey_tweak_add(const secp256k1_context *ctx,
+                                   const unsigned char *tweak, size_t tweak_len,
+                                   struct ext_key *key_out)
+{
+    if (!ctx || !tweak || tweak_len != sizeof(key_out->pub_key_tweak_sum) || !key_out)
+        return WALLY_EINVAL;
+
+    if (!mem_is_zero(key_out->pub_key_tweak_sum, tweak_len))
+        return privkey_tweak_add(ctx, key_out->pub_key_tweak_sum, tweak) ? WALLY_OK : WALLY_EINVAL;
+
+    /* tweak sum is zero: start wih the tweak */
+    memcpy(key_out->pub_key_tweak_sum, tweak, tweak_len);
+    return WALLY_OK;
+}
+#endif /* BUILD_ELEMENTS */
+
 /* BIP32: Child Key Derivations
  *
  * The spec doesn't have a simple table of derivations, its:
@@ -453,7 +470,7 @@ int bip32_key_from_parent(const struct ext_key *hdkey, uint32_t child_num,
             len != sizeof(key_out->pub_key)
 #ifdef BUILD_ELEMENTS
             || ((flags & BIP32_FLAG_KEY_TWEAK_SUM) &&
-                !privkey_tweak_add(ctx, key_out->pub_key_tweak_sum, sha.u.u8))
+                bip32_privkey_tweak_add(ctx, sha.u.u8, SHA256_LEN, key_out) != WALLY_OK)
 #endif /* BUILD_ELEMENTS */
             ) {
             wally_clear(&sha, sizeof(sha));


### PR DESCRIPTION
Based on a patch by @k-matsuzawa
