### PR TITLE
SWIG Python: Fix handling of bad capsule pointers

### DIFF
--- a/src/swig_python/swig.i
+++ b/src/swig_python/swig.i
@@ -220,9 +220,17 @@ static void destroy_words(PyObject *obj) { (void)obj; }
 }
 %typemap (in) const struct NAME * {
     $1 = $input == Py_None ? NULL : PyCapsule_GetPointer($input, "struct NAME *");
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+        %argument_fail(-1, "(NAME)", $symname, $argnum);
+    }
 }
 %typemap (in) struct NAME * {
     $1 = $input == Py_None ? NULL : PyCapsule_GetPointer($input, "struct NAME *");
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+        %argument_fail(-1, "(NAME)", $symname, $argnum);
+    }
 }
 %enddef
 


### PR DESCRIPTION
See commit for details. Now returns a message of the form:

````
TypeError: in method 'tx_to_hex', argument 1 of type '(wally_tx)'
````

If an invalid or wrong type of object is passed.