### PR TITLE
psbt: correctly parse the 'empty tx'

### DIFF
--- a/src/data/psbt.json
+++ b/src/data/psbt.json
@@ -56,7 +56,12 @@
           "comment": "Partial transaction (with no outputs)",
           "psbt": "cHNidP8BADMCAAAAAZCmTNqA77Z44FTcG0k2D2xkazaLwfTcYgkhBHT1hFy0AAAAAAD9////AGYAAAAAAQEgQEIPAAAAAAAXqRRlVyjzbP420BqlDTI2cERp+EpVQIcBBBYAFNa5adNt/9rZhpGT9mPuSA39xzSIAA==",
           "len": 121
-        }
+        },
+	{
+	  "comment": "PSBT of the empty transaction '00000000000000000000'",
+	  "psbt": "cHNidP8BAAoAAAAAAAAAAAAAAA==",
+	  "len": 19
+	}
     ],
     "creator" : [
         {

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -2326,6 +2326,9 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
         *expect_witnesses = *p++ != 0;
     else {
         if (*p == 0) {
+            /* Is this the 'empty tx' */
+            if (p[1] == 0x0 && bytes_len == 10)
+                goto next;
             /* BIP 144 extended serialization */
             if (p[1] != 0x1)
                 return WALLY_EINVAL; /* Invalid witness flag */
@@ -2333,6 +2336,8 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
             *expect_witnesses = true;
         }
     }
+
+next:
 
 #define ensure_n(n) if (p > end || p + (n) > end) return WALLY_EINVAL
 


### PR DESCRIPTION
c-lightning removes/adds things to a PSBT; if we remove everything
libwally fails to parse it.

Here we fix the parsing error for the 'empty tx' and add a test case for
the PSBT of it.