### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ installed.
 For non-development use, you can install wally with `pip` as follows:
 
 ```
-pip install wallycore==0.8.2
+pip install wallycore==0.8.3
 ```
 
 For python development, you can build and install wally using:
@@ -124,7 +124,7 @@ You can also install the binary [wally releases](https://github.com/ElementsProj
 using the released wheel files without having to compile the library, e.g.:
 
 ```
-pip install wallycore-0.8.2-cp37-cp37m-linux_x86_64.whl
+pip install wallycore-0.8.3-cp37-cp37m-linux_x86_64.whl
 ```
 
 The script `tools/build_python_manylinux_wheels.sh` builds the Linux release files

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([libwallycore],[0.8.2])
+AC_INIT([libwallycore],[0.8.3])
 AC_CONFIG_AUX_DIR([tools/build-aux])
 AC_CONFIG_MACRO_DIR([tools/build-aux/m4])
 AC_CONFIG_SRCDIR([src/mnemonic.h])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ author = u'Jon Griffiths'
 # built documents.
 #
 # The short X.Y version.
-version = u'0.8.2'
+version = u'0.8.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -39,6 +39,7 @@ extern "C" {
 #define WALLY_SIGHASH_NONE         0x02
 #define WALLY_SIGHASH_SINGLE       0x03
 #define WALLY_SIGHASH_FORKID       0x40
+#define WALLY_SIGHASH_RANGEPROOF   0x40  /* for elements */
 #define WALLY_SIGHASH_ANYONECANPAY 0x80
 
 #define WALLY_TX_ASSET_CT_VALUE_PREFIX_A 8

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 kwargs = {
     'name': 'wallycore',
-    'version': '0.8.2',
+    'version': '0.8.3',
     'description': 'libwally Bitcoin library',
     'long_description': 'Python bindings for the libwally Bitcoin library',
     'url': 'https://github.com/ElementsProject/libwally-core',

--- a/src/wrap_js/cordovaplugin/yarn.lock
+++ b/src/wrap_js/cordovaplugin/yarn.lock
@@ -789,9 +789,9 @@ has-values@^1.0.0:
     kind-of "^4.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 http-errors@1.7.2:
   version "1.7.2"


### PR DESCRIPTION
Update cordova dependencies. Adds sighash rangeproof support (without tests, but since the code is conditional on the sighash flag, these can be added later).