### PR TITLE
removed a trailing tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ source $HOME/emsdk/emsdk_env.sh
 # Optionally set the list of wally functions to export to wasm (default: all)
 $ export EXPORTED_FUNCTIONS="['_malloc','_free','_wally_init','_wally_cleanup',...]"
 
-`# Build
+# Build
 $ ./tools/build_wasm.sh [--enable-elements]
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ And can be used from:
 # Initialise the libsecp sources (Needs to be run only once)
 $ git submodule init
 $ git submodule sync --recursive
-$ git submodule update --init --recursive`
+$ git submodule update --init --recursive
 
 # Build
 $ ./tools/autogen.sh


### PR DESCRIPTION
There was a trailing character in the readme "`" that was causing some issue when copying some of the text.