### PR TITLE
autogen: use gsed

### DIFF
--- a/tools/autogen.sh
+++ b/tools/autogen.sh
@@ -4,7 +4,7 @@ if uname | grep "Darwin" >/dev/null 2>&1; then
     # Hack libtool to work around OSX requiring AR set to /usr/bin/libtool
     for f in ./tools/build-aux/ltmain.sh ./src/secp256k1/build-aux/ltmain.sh; do
         for a in x t; do
-             sed -i -e "s/\$AR $a /ar $a /" $f
+             gsed -i -e "s/\$AR $a /ar $a /" $f
         done
     done
 fi


### PR DESCRIPTION
See https://github.com/bitcoin-core/secp256k1/pull/998

The README already states that `gnu-sed` is a requirement for macOS.