### PR TITLE
Add build-aux/ar-lib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ src/swig_python/wallycore/wallycore.egg-info
 tools/build-aux/m4/l*.m4
 tools/build-aux/test-driver
 tools/build-aux/*-e
+tools/build-aux/ar-lib
 src/secp256k1/build-aux/*-e
 src/secp256k1/test-suite.log
 src/secp256k1/*.log


### PR DESCRIPTION
This folder gets created since I bumped from 0.8.4 to 0.8.5, at least when using my own build script. See https://github.com/Sjors/libwally-swift/pull/62