### PR TITLE
fix: add WALLY_CORE_API, and use c_size_t on python test (for windows)

### DIFF
--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -298,7 +298,7 @@ WALLY_CORE_API int bip32_key_from_parent_path_alloc(
  * :param flags: ``BIP32_FLAG_`` Flags indicating the type of derivation wanted.
  * :param output: Destination for the resulting child extended key.
  */
-int bip32_key_from_parent_path_str(
+WALLY_CORE_API int bip32_key_from_parent_path_str(
     const struct ext_key *hdkey,
     const char *path_str,
     uint32_t child_num,
@@ -310,7 +310,7 @@ int bip32_key_from_parent_path_str(
  *
  * See `bip32_key_from_parent_path_str`.
  */
-int bip32_key_from_parent_path_str_n(
+WALLY_CORE_API int bip32_key_from_parent_path_str_n(
     const struct ext_key *hdkey,
     const char *path_str,
     size_t path_str_len,
@@ -323,7 +323,7 @@ int bip32_key_from_parent_path_str_n(
  * As per `bip32_key_from_parent_path_str`, but allocates the key.
  * .. note:: The returned key should be freed with `bip32_key_free`.
  */
-int bip32_key_from_parent_path_str_alloc(
+WALLY_CORE_API int bip32_key_from_parent_path_str_alloc(
     const struct ext_key *hdkey,
     const char *path_str,
     uint32_t child_num,
@@ -334,7 +334,7 @@ int bip32_key_from_parent_path_str_alloc(
  * As per `bip32_key_from_parent_path_str_n`, but allocates the key.
  * .. note:: The returned key should be freed with `bip32_key_free`.
  */
-int bip32_key_from_parent_path_str_n_alloc(
+WALLY_CORE_API int bip32_key_from_parent_path_str_n_alloc(
     const struct ext_key *hdkey,
     const char *path_str,
     size_t path_str_len,

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -69,58 +69,58 @@ c_uint_p = POINTER(c_uint)
 
 class wally_tx_witness_item(Structure):
     _fields_ = [('witness', c_void_p),
-                ('len', c_ulong)]
+                ('len', c_size_t)]
 
 class wally_tx_witness_stack(Structure):
     _fields_ = [('items', POINTER(wally_tx_witness_item)),
-                ('num_items', c_ulong),
-                ('items_allocation_len', c_ulong)]
+                ('num_items', c_size_t),
+                ('items_allocation_len', c_size_t)]
 
 class wally_tx_input(Structure):
     _fields_ = [('txhash', c_ubyte * 32),
                 ('index', c_uint),
                 ('sequence', c_uint),
                 ('script', c_void_p),
-                ('script_len', c_ulong),
+                ('script_len', c_size_t),
                 ('witness',  POINTER(wally_tx_witness_stack)),
                 ('features', c_ubyte),
                 ('blinding_nonce', c_ubyte * 32),
                 ('entropy', c_ubyte * 32),
                 ('issuance_amount', c_void_p),
-                ('issuance_amount_len', c_ulong),
+                ('issuance_amount_len', c_size_t),
                 ('inflation_keys', c_void_p),
-                ('inflation_keys_len', c_ulong),
+                ('inflation_keys_len', c_size_t),
                 ('issuance_amount_rangeproof', c_void_p),
-                ('issuance_amount_rangeproof_len', c_ulong),
+                ('issuance_amount_rangeproof_len', c_size_t),
                 ('inflation_keys_rangeproof', c_void_p),
-                ('inflation_keys_rangeproof_len', c_ulong),
+                ('inflation_keys_rangeproof_len', c_size_t),
                 ('pegin_witness', POINTER(wally_tx_witness_stack))]
 
 class wally_tx_output(Structure):
     _fields_ = [('satoshi', c_uint64),
                 ('script', c_void_p),
-                ('script_len', c_ulong),
+                ('script_len', c_size_t),
                 ('features', c_ubyte),
                 ('asset', c_void_p),
-                ('asset_len', c_ulong),
+                ('asset_len', c_size_t),
                 ('value', c_void_p),
-                ('value_len', c_ulong),
+                ('value_len', c_size_t),
                 ('nonce', c_void_p),
-                ('nonce_len', c_ulong),
+                ('nonce_len', c_size_t),
                 ('surjectionproof', c_void_p),
-                ('surjectionproof_len', c_ulong),
+                ('surjectionproof_len', c_size_t),
                 ('rangeproof', c_void_p),
-                ('rangeproof_len', c_ulong)]
+                ('rangeproof_len', c_size_t)]
 
 class wally_tx(Structure):
-    _fields_ = [('version', c_uint),
-                ('locktime', c_uint),
+    _fields_ = [('version', c_uint32),
+                ('locktime', c_uint32),
                 ('inputs', POINTER(wally_tx_input)),
-                ('num_inputs', c_ulong),
-                ('inputs_allocation_len', c_ulong),
+                ('num_inputs', c_size_t),
+                ('inputs_allocation_len', c_size_t),
                 ('outputs', POINTER(wally_tx_output)),
-                ('num_outputs', c_ulong),
-                ('outputs_allocation_len', c_ulong),]
+                ('num_outputs', c_size_t),
+                ('outputs_allocation_len', c_size_t),]
 
 class wally_map_item(Structure):
     _fields_ = [('key', c_void_p),


### PR DESCRIPTION
1. Add `WALLY_CORE_API` because it was not defined for the following functions.
    * bip32_key_from_parent_path_str
    * bip32_key_from_parent_path_str_n
    * bip32_key_from_parent_path_str_alloc
    * bip32_key_from_parent_path_str_n_alloc

2. Some of the tests with src/test on Windows were not working properly. I was able to confirm that the parts of wally_transaction.h where size_t is used work correctly by changing from c_ulong to c_size_t in the util.py.
