### PR TITLE
Bip32 updates

### DIFF
--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -37,6 +37,8 @@ extern "C" {
 #define BIP32_FLAG_STR_WILDCARD 0x8
 /** Do not allow a leading ``m``/``M`` or ``/`` in path string expressions */
 #define BIP32_FLAG_STR_BARE 0x10
+/** Allow upper as well as lower case 'M'/'H' in path string expressions */
+#define BIP32_FLAG_ALLOW_UPPER 0x20
 
 /** Version codes for extended keys */
 #define BIP32_VER_MAIN_PUBLIC  0x0488B21E

--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -270,6 +270,9 @@ WALLY_CORE_API int bip32_key_from_parent_alloc(
  * :param child_path_len: The number of child numbers in ``child_path``.
  * :param flags: ``BIP32_FLAG_`` Flags indicating the type of derivation wanted.
  * :param output: Destination for the resulting child extended key.
+ *
+ * .. note:: If ``child_path`` contains hardened child numbers, then ``hdkey``
+ *           must be an extended private key or this function will fail.
  */
 WALLY_CORE_API int bip32_key_from_parent_path(
     const struct ext_key *hdkey,
@@ -299,6 +302,9 @@ WALLY_CORE_API int bip32_key_from_parent_path_alloc(
  * :param child_num: The child number to use if ``path_str`` contains a ``*`` wildcard.
  * :param flags: ``BIP32_FLAG_`` Flags indicating the type of derivation wanted.
  * :param output: Destination for the resulting child extended key.
+ *
+ * .. note:: If ``child_path`` contains hardened child numbers, then ``hdkey``
+ *           must be an extended private key or this function will fail.
  */
 WALLY_CORE_API int bip32_key_from_parent_path_str(
     const struct ext_key *hdkey,


### PR DESCRIPTION
Includes the bip32 mixed-hardened/non-hardened derivation fixes and upper case bip32 path changes from the descriptor PR, plus adds a couple more test cases from @JamieDriver 