### PR TITLE
skip non-applicable tests if BUILD_STANDARD_SECP

### DIFF
--- a/src/test/test_anti_exfil.py
+++ b/src/test/test_anti_exfil.py
@@ -9,6 +9,7 @@ class AntiExfilTests(unittest.TestCase):
         conv = lambda v: make_cbuffer(v)[0] if type(v) is str else v
         return [conv(v) for v in values]
 
+    @unittest.skipUnless(wally_ae_sig_from_bytes, "anti-exfil module not enabled")
     def test_anti_exfil(self):
         entropy, host_commitment, signer_commitment, priv_key, pub_key, msg, sig = self.cbufferize(
             ['11' * 32, '00' * 32, '00' * 33, '22' * 32, '00' * 33, '33' * 32, '00' * 64])

--- a/src/test/test_sign.py
+++ b/src/test/test_sign.py
@@ -254,6 +254,7 @@ class SignTests(unittest.TestCase):
             ]:
             self.assertEqual(WALLY_EINVAL, wally_ec_sig_to_public_key(*args))
 
+    @unittest.skipUnless(wally_s2c_sig_from_bytes, "s2c module not enabled")
     def test_s2c(self):
         priv_key, pub_key, msg, s2c_data, sig_out, s2c_opening_out = self.cbufferize(
             ['11' * 32, '00' * 32, '22' * 32, '33' * 32, '00' * 64, '00' * 33])


### PR DESCRIPTION
`src/anti_exfil.c` is empty if `BUILD_STANDARD_SECP`, so `src/test/test_anti_exfil.py` fails with:

```
ERROR: test_anti_exfil (__main__.AntiExfilTests.test_anti_exfil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/test/test_anti_exfil.py", line 21, in test_anti_exfil
    ret = wally_ae_host_commit_from_bytes(entropy, 32, flags, host_commitment, 32)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```

Furthermore, `src/sign.c` omits `wally_s2c_sig_from_bytes` and `wally_s2c_commitment_verify` if `BUILD_STANDARD_SECP`, so `src/test/test_sign.py` fails with:

```
ERROR: test_s2c (__main__.SignTests.test_s2c)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/test/test_sign.py", line 263, in test_s2c
    self.assertEqual(WALLY_OK, wally_s2c_sig_from_bytes(priv_key, 32, msg, 32, s2c_data, 32, flags, s2c_opening_out, 33, sig_out, 64))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```