### PR TITLE
build-system: cmake generating config.h

### DIFF
--- a/_CMakeLists.txt
+++ b/_CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(
+  libwallycore
+  VERSION 0.8.8
+  DESCRIPTION "collection of useful primitives for cryptocurrency wallets"
+  LANGUAGES C)
+
+include(cmake/utils.cmake)
+generate_config_file()

--- a/_cmake/config.h.in
+++ b/_cmake/config.h.in
@@ -1,0 +1,82 @@
+#ifndef LIBWALLYCORE_CONFIG_H
+#define LIBWALLYCORE_CONFIG_H
+
+/* Define if building universal (internal helper macro) */
+#cmakedefine AC_APPLE_UNIVERSAL_BUILD @AC_APPLE_UNIVERSAL_BUILD@
+
+/* Define to 1 if you have the <asm/page.h> header file. */
+#cmakedefine HAVE_ASM_PAGE_H @HAVE_ASM_PAGE_H@
+
+
+/* Define to 1 if you have the <byteswap.h,> header file. */
+#cmakedefine HAVE_BYTESWAP_H @HAVE_BYTESWAP_H@
+
+/* Define to 1 if you have the `explicit_bzero' function. */
+#cmakedefine HAVE_EXPLICIT_BZERO @HAVE_EXPLICIT_BZERO@
+
+/* Define to 1 if you have the `explicit_memset' function. */
+#cmakedefine HAVE_EXPLICIT_MEMSET @HAVE_EXPLICIT_MEMSET@
+
+/* inline asm code can be used */
+#cmakedefine HAVE_INLINE_ASM @HAVE_INLINE_ASM@
+
+/* Define to 1 if you have the <mbedtls/sha256.h,> header file. */
+#cmakedefine HAVE_MBEDTLS_SHA256_H_ @HAVE_MBEDTLS_SHA256_H@
+
+/* Define to 1 if you have the <mbedtls/sha512.h> header file. */
+#cmakedefine HAVE_MBEDTLS_SHA512_H @HAVE_MBEDTLS_SHA512_H@
+
+/* Define to 1 if you have the `memset_s' function. */
+#cmakedefine HAVE_MEMSET_S @HAVE_MEMSET_S@
+
+/* Define if we have mmap */
+#cmakedefine HAVE_MMAP @HAVE_MMAP@
+
+/* Define if we have posix_memalign */
+#cmakedefine HAVE_POSIX_MEMALIGN @HAVE_POSIX_MEMALIGN@
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#cmakedefine HAVE_SYS_MMAN_H @HAVE_SYS_MMAN_H@
+
+/* Define if we have unaligned access */
+#cmakedefine HAVE_UNALIGNED_ACCESS @HAVE_UNALIGNED_ACCESS@
+
+/* Name of package */
+#cmakedefine PACKAGE @PACKAGE@
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT @PACKAGE_BUGREPORT@
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME @PACKAGE_NAME@
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING @PACKAGE_STRING@
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME @PACKAGE_TARNAME@
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL @PACKAGE_URL@
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION @PACKAGE_VERSION@
+
+/* Version number of package */
+#cmakedefine VERSION @VERSION@
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#cmakedefine WORDS_BIGENDIAN @WORDS_BIGENDIAN@
+# endif
+#endif
+
+
+#include "ccan_config.h"
+#endif /*LIBWALLYCORE_CONFIG_H*/

--- a/_cmake/utils.cmake
+++ b/_cmake/utils.cmake
@@ -1,0 +1,34 @@
+include(CheckCCompilerFlag)
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+include(CheckCSourceRuns)
+
+function(generate_config_file)
+    check_function_exists("explicit_bzero" HAVE_EXPLICIT_BZERO)
+    check_function_exists("explicit_memset" HAVE_EXPLICIT_MEMSET)
+    check_c_source_compiles(
+        "int main(void) {int a = 42; int *pnt = &a; __asm__ __volatile__ (\"\" : : \"r\"(pnt) : \"memory\");}"
+        HAVE_INLINE_ASM
+    )
+    check_include_file("mbedtls/sha512.h" HAVE_MBEDTLS_SHA512_H)
+    check_function_exists("mmap" HAVE_MMAP)
+    check_function_exists("posix_memalign" HAVE_POSIX_MEMALIGN)
+    check_include_file("sys/mman.h" HAVE_SYS_MMAN_H)
+    if(CMAKE_CROSSCOMPILING)
+        unset(HAVE_UNALIGNED_ACCESS)
+    else()
+        check_c_source_runs(
+            "int main(void){static int a[2];return *((int*)(((char*)a)+1)) != 0;}" HAVE_UNALIGNED_ACCESS
+        )
+    endif()
+    set(PACKAGE \"${CMAKE_PROJECT_NAME}\")
+    set(PACKAGE_BUGREPORT \"\")
+    set(PACKAGE_NAME \"${CMAKE_PROJECT_NAME}\")
+    set(PACKAGE_STRING "\"${CMAKE_PROJECT_NAME} ${CMAKE_PROJECT_VERSION}\"")
+    set(PACKAGE_TARNAME \"${CMAKE_PROJECT_NAME}\")
+    set(PACKAGE_URL \"${CMAKE_PROJECT_URL}\")
+    set(PACKAGE_VERSION \"${CMAKE_PROJECT_VERSION}\")
+    set(VERSION \"${CMAKE_PROJECT_VERSION}\")
+
+    configure_file(cmake/config.h.in config.h)
+endfunction()


### PR DESCRIPTION
First introduction of cmake to generate the config.h file, mirroring the config.h file genrated by autoheader


FYI: @k-matsuzawa 





##### note for reviewers:
``_cmake`` folder and main ``CMakeLists.txt`` file are intentionally prefixed with ``_`` to avoid possible conflicts to any 3rd parties who forked the project to implement their own cmake build system.

As the cmake introduction in this repository will be incremental, we would like to create the least amount of disruption to others