### PR TITLE
Alignment changes

### DIFF
--- a/src/ccan_config.h
+++ b/src/ccan_config.h
@@ -28,6 +28,16 @@
 #define HAVE_BSWAP_64 0
 #endif
 
+#if defined(HAVE_UNALIGNED_ACCESS) && defined(__arm__)
+/* arm unaligned access is incomplete, in that e.g. byte swap instructions
+ * can fault on unaligned addresses where a normal load/store would be fine.
+ * Since the compiler can optimise some of our accesses into operations like
+ * byte swaps, treat this platform as though it doesn't have unaligned access.
+ */
+#undef HAVE_UNALIGNED_ACCESS
+#define HAVE_UNALIGNED_ACCESS 0
+#endif
+
 #if HAVE_UNALIGNED_ACCESS
 #define alignment_ok(p, n) 1
 #else

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -1062,18 +1062,19 @@ static int generate_pk_k(ms_ctx *ctx, ms_node *node,
 static int generate_pk_h(ms_ctx *ctx, ms_node *node,
                          unsigned char *script, size_t script_len, size_t *written)
 {
-    unsigned char buff[1 + EC_PUBLIC_KEY_UNCOMPRESSED_LEN];
+    /* Note 4 instead of 1 here to align the data to hash to 32 bits */
+    unsigned char buff[4 + EC_PUBLIC_KEY_UNCOMPRESSED_LEN];
     int ret = WALLY_OK;
 
     if (script_len >= WALLY_SCRIPTPUBKEY_P2PKH_LEN - 1) {
-        ret = generate_pk_k(ctx, node, buff, sizeof(buff), written);
+        ret = generate_pk_k(ctx, node, buff+3, sizeof(buff)-3, written);
         if (ret == WALLY_OK) {
             if (node->child->flags & NF_IS_XONLY)
                 return WALLY_EINVAL;
             script[0] = OP_DUP;
             script[1] = OP_HASH160;
             script[2] = HASH160_LEN;
-            ret = wally_hash160(&buff[1], *written - 1, script + 3, HASH160_LEN);
+            ret = wally_hash160(buff+4, *written - 1, script + 3, HASH160_LEN);
             script[3 + HASH160_LEN] = OP_EQUALVERIFY;
         }
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -174,7 +174,7 @@ int wally_sha256(const unsigned char *bytes, size_t bytes_len,
                  unsigned char *bytes_out, size_t len)
 {
     struct sha256 sha;
-    bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u32));
+    const bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u32[0]));
 
     if ((!bytes && bytes_len != 0) || !bytes_out || len != SHA256_LEN)
         return WALLY_EINVAL;
@@ -210,7 +210,7 @@ int wally_sha256_midstate(const unsigned char *bytes, size_t bytes_len,
 {
     struct sha256 sha;
     struct sha256_ctx ctx;
-    bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u32));
+    const bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u32[0]));
 
     if ((!bytes && bytes_len != 0) || !bytes_out || len != SHA256_LEN)
         return WALLY_EINVAL;
@@ -236,7 +236,7 @@ int wally_sha256d(const unsigned char *bytes, size_t bytes_len,
                   unsigned char *bytes_out, size_t len)
 {
     struct sha256 sha_1, sha_2;
-    bool aligned = alignment_ok(bytes_out, sizeof(sha_1.u.u32));
+    const bool aligned = alignment_ok(bytes_out, sizeof(sha_1.u.u32[0]));
 
     if ((!bytes && bytes_len != 0) || !bytes_out || len != SHA256_LEN)
         return WALLY_EINVAL;
@@ -255,7 +255,7 @@ int wally_sha512(const unsigned char *bytes, size_t bytes_len,
                  unsigned char *bytes_out, size_t len)
 {
     struct sha512 sha;
-    bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u64));
+    const bool aligned = alignment_ok(bytes_out, sizeof(sha.u.u64[0]));
 
     if ((!bytes && bytes_len != 0) || !bytes_out || len != SHA512_LEN)
         return WALLY_EINVAL;
@@ -272,7 +272,7 @@ int wally_ripemd160(const unsigned char *bytes, size_t bytes_len,
                     unsigned char *bytes_out, size_t len)
 {
     struct ripemd160 ripemd;
-    const bool aligned = alignment_ok(bytes_out, sizeof(ripemd.u.u32));
+    const bool aligned = alignment_ok(bytes_out, sizeof(ripemd.u.u32[0]));
 
     if ((!bytes && bytes_len != 0) || !bytes_out || len != RIPEMD160_LEN)
         return WALLY_EINVAL;
@@ -292,7 +292,7 @@ int wally_hash160(const unsigned char *bytes, size_t bytes_len,
 {
     unsigned char buff[SHA256_LEN];
     struct ripemd160 ripemd;
-    const bool aligned = alignment_ok(bytes_out, sizeof(ripemd.u.u32));
+    const bool aligned = alignment_ok(bytes_out, sizeof(ripemd.u.u32[0]));
 
     if (!bytes_out || len != HASH160_LEN)
         return WALLY_EINVAL;


### PR DESCRIPTION
- Fix alignment checks for hashes which would slightly pessimize strong alignment targets.
- Align pk_h hash output for better hash performance.
- Mark arm 32bit as not supporting unaligned access.

The last commit fixes a crash on Rasbian reported by @jmastr, thanks for the bug report!

Fixes https://github.com/ElementsProject/libwally-core/issues/396