### PR TITLE
Misc updates

### DIFF
--- a/src/ctest/test_psbt_limits.c
+++ b/src/ctest/test_psbt_limits.c
@@ -10,7 +10,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #if 0
 #include <assert.h>
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -328,12 +328,12 @@ static void wally_internal_bzero(void *dest, size_t len)
     explicit_memset(dest, 0, len);
 #else
     memset(dest, 0, len);
+#endif
 #if defined(HAVE_INLINE_ASM)
     /* This is used by boringssl to prevent memset from being elided. It
      * works by forcing a memory barrier and so can be slow.
      */
     __asm__ __volatile__ ("" : : "r" (dest) : "memory");
-#endif
 #endif
 }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -111,4 +111,13 @@ int map_add_preimage_and_hash(struct wally_map *map_in,
 const struct wally_map_item *map_find_equal_integer(const struct wally_map *lhs,
                                                     const struct wally_map *rhs,
                                                     uint32_t key);
+
+/* Clamp input/output allocation sizing to standard tx sizes for BTC.
+ * Liquid numbers are smaller; we use the upper limit */
+#define TX_MAX_INPUTS_ALLOC 1738u
+#define TX_MAX_OUTPUTS_ALLOC 3224u
+
+/* Clamp initial witness stack allocation sizing */
+#define MAX_WITNESS_ITEMS_ALLOC 100u /* Non-Taproot standardness limit */
+
 #endif /* LIBWALLY_INTERNAL_H */

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -1096,10 +1096,16 @@ static int wally_psbt_init(uint32_t version, size_t num_inputs, size_t num_outpu
         return WALLY_EINVAL;
 #endif /* BUILD_ELEMENTS */
 
-    if (num_inputs)
+    if (num_inputs) {
+        if (num_inputs > TX_MAX_INPUTS_ALLOC)
+            num_inputs = TX_MAX_INPUTS_ALLOC;
         psbt_out->inputs = wally_calloc(num_inputs * sizeof(struct wally_psbt_input));
-    if (num_outputs)
+    }
+    if (num_outputs) {
+        if (num_outputs > TX_MAX_OUTPUTS_ALLOC)
+            num_outputs = TX_MAX_OUTPUTS_ALLOC;
         psbt_out->outputs = wally_calloc(num_outputs * sizeof(struct wally_psbt_output));
+    }
 
     ret = wally_map_init(num_unknowns, NULL, &psbt_out->unknowns);
     if (ret == WALLY_OK)

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -196,6 +196,8 @@ int wally_tx_witness_stack_init_alloc(size_t allocation_len,
     OUTPUT_ALLOC(struct wally_tx_witness_stack);
 
     if (allocation_len) {
+        if (allocation_len > MAX_WITNESS_ITEMS_ALLOC)
+            allocation_len = MAX_WITNESS_ITEMS_ALLOC;
         (*output)->items = wally_calloc(allocation_len * sizeof(struct wally_tx_witness_item));
         if (!(*output)->items) {
             wally_free(*output);
@@ -1090,10 +1092,16 @@ int wally_tx_init_alloc(uint32_t version, uint32_t locktime,
     OUTPUT_CHECK;
     OUTPUT_ALLOC(struct wally_tx);
 
-    if (inputs_allocation_len)
+    if (inputs_allocation_len) {
+        if (inputs_allocation_len > TX_MAX_INPUTS_ALLOC)
+            inputs_allocation_len = TX_MAX_INPUTS_ALLOC;
         new_inputs = wally_calloc(inputs_allocation_len * sizeof(struct wally_tx_input));
-    if (outputs_allocation_len)
+    }
+    if (outputs_allocation_len) {
+        if (outputs_allocation_len > TX_MAX_OUTPUTS_ALLOC)
+            outputs_allocation_len = TX_MAX_OUTPUTS_ALLOC;
         new_outputs = wally_calloc(outputs_allocation_len * sizeof(struct wally_tx_output));
+    }
     if ((inputs_allocation_len && !new_inputs) ||
         (outputs_allocation_len && !new_outputs)) {
         wally_free(new_inputs);


### PR DESCRIPTION
- unilaterally force a memory barrier for memory clearing
- fix test_psbt_limits compilation under msvcrt
- clamp initial pre-allocation sizes to prevent DOS