### PR TITLE
build-system: compile libsecp and wallycore with cmake

### DIFF
--- a/_CMakeLists.txt
+++ b/_CMakeLists.txt
@@ -1,10 +1,61 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 
 project(
   libwallycore
   VERSION 0.8.8
   DESCRIPTION "collection of useful primitives for cryptocurrency wallets"
-  LANGUAGES C)
+  LANGUAGES C
+)
+
+option(BUILD_SHARED_LIBS "Build as shared library" OFF)
+
 
 include(cmake/utils.cmake)
 generate_config_file()
+configure_file(src/ccan_config.h ccan_config.h COPYONLY)
+
+include(cmake/libsecp256k1.cmake)
+
+add_subdirectory(src)
+
+
+### install directives
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(LIB_CMAKE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/wallycore)
+
+configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/wallycore-config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/wallycore-config.cmake"
+    INSTALL_DESTINATION ${LIB_CMAKE_INSTALL_DIR}
+    PATH_VARS LIB_CMAKE_INSTALL_DIR
+)
+write_basic_package_version_file(
+    wallycore-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/wallycore-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/wallycore-config-version.cmake"
+    DESTINATION
+        ${LIB_CMAKE_INSTALL_DIR}
+)
+install(
+    TARGETS wallycore
+    EXPORT "wallycore-target"
+    COMPONENT wallycore
+    RUNTIME EXCLUDE_FROM_ALL
+    OBJECTS EXCLUDE_FROM_ALL
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT "wallycore-target"
+    DESTINATION ${LIB_CMAKE_INSTALL_DIR}
+    NAMESPACE wallycore::
+    FILE "wallycore-targets.cmake"
+)
+

--- a/_cmake/libsecp256k1-pkgconfig.cmake
+++ b/_cmake/libsecp256k1-pkgconfig.cmake
@@ -1,0 +1,21 @@
+### Update libsecp256k1.pc to fix its installation prefix
+
+cmake_path(ABSOLUTE_PATH CMAKE_INSTALL_PREFIX OUTPUT_VARIABLE _absolute_prefix )
+find_file(_secp_pkg_cfg libsecp256k1.pc
+    PATHS ${_absolute_prefix}
+    PATH_SUFFIXES lib/pkgconfig
+)
+if(NOT _secp_pkg_cfg)
+    message(FATAL_ERROR "pkg-config file for libsecp256k1 not found, please check your cmake build system")
+endif()
+
+file(STRINGS ${_secp_pkg_cfg} _libsecpLines)
+file(WRITE ${_secp_pkg_cfg} "")
+foreach(line ${_libsecpLines})
+    string(REGEX MATCH "^prefix=.*" out ${line})
+    if (out)
+        file(APPEND ${_secp_pkg_cfg} "prefix=${_absolute_prefix}\n")
+    else()
+        file(APPEND ${_secp_pkg_cfg} "${line}\n")
+    endif()
+endforeach()

--- a/_cmake/libsecp256k1.cmake
+++ b/_cmake/libsecp256k1.cmake
@@ -1,0 +1,116 @@
+
+include(ExternalProject)
+include(GNUInstallDirs)
+
+find_program(MAKE_EXE NAMES gmake nmake make)
+
+set(_secp_enable_tests --disable-tests)
+if(ENABLE_TESTS)
+    set(_secp_enable_tests --enable-tests)
+endif()
+set(_secp_with_asm --with-asm=no)
+if(ENABLE_ASM AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(_secp_with_asm --with-asm=yes)
+endif()
+
+set(_secp_lib_type STATIC)
+set(_secp_lib_type_option --disable-shared)
+if(BUILD_SHARED_LIBS)
+    set(_secp_lib_type SHARED)
+    set(_secp_lib_type_option --enable-shared)
+endif()
+
+set(_secp_host_build_config "")
+if(CMAKE_CROSSCOMPILING)
+    if(NOT CONFIGURE_AC_HOST)
+        message(FATAL_ERROR "when cross-building, please define CONFIGURE_AC_HOST to be passed to libsecp256k1 as --host=<CONFIGURE_AC_HOST>")
+    endif()
+    if(NOT CONFIGURE_AC_BUILD)
+        message(FATAL_ERROR "when cross-building, please define CONFIGURE_AC_BUILD to be passed to libsecp256k1 as --build=<CONFIGURE_AC_BUILD>")
+    endif()
+    set(_secp_host_build_config "--host=${CONFIGURE_AC_HOST} --build=${CONFIGURE_AC_BUILD}")
+endif()
+
+if(CMAKE_BUILD_TYPE)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UC)
+endif()
+
+
+ExternalProject_Add(libsecp256k1-build
+    DOWNLOAD_COMMAND ""
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/secp256k1
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure
+        "CC=${CMAKE_C_COMPILER}"
+        "AR=${CMAKE_AR}"
+        "RANLIB=${CMAKE_C_COMPILER_RANLIB}"
+        "CFLAGS=${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UC}}"
+        "LDFLAGS=${CMAKE_${_secp_lib_type}_LINKER_FLAGS} ${CMAKE_${_secp_lib_type}_LINKER_FLAGS_${BUILD_TYPE_UC}}"
+        --prefix <INSTALL_DIR>
+        ${_secp_lib_type_option}
+        --with-pic
+        --with-bignum=no
+        --enable-experimental
+        --enable-module-ecdh
+        --enable-module-recovery
+        --enable-module-ecdsa-s2c
+        --enable-module-rangeproof
+        --enable-module-surjectionproof
+        --enable-module-whitelist
+        --enable-module-generator
+        --enable-module-extrakeys
+        --enable-module-schnorrsig
+        --enable-openssl-tests=no
+        --enable-exhaustive-tests=no
+        --enable-benchmark=no
+        --disable-dependency-tracking
+        ${_secp_enable_tests}
+        ${_secp_with_asm}
+        ${_secp_host_build_config}
+
+    BUILD_COMMAND ${MAKE_EXE}
+
+    INSTALL_COMMAND ${MAKE_EXE} install
+)
+
+
+ExternalProject_Get_Property(libsecp256k1-build INSTALL_DIR)
+
+add_library(libsecp256k1 STATIC IMPORTED)
+set(_secp_public_headers
+    ${INSTALL_DIR}/include/secp256k1_ecdh.h
+    ${INSTALL_DIR}/include/secp256k1_ecdsa_s2c.h
+    ${INSTALL_DIR}/include/secp256k1_extrakeys.h
+    ${INSTALL_DIR}/include/secp256k1_generator.h
+    ${INSTALL_DIR}/include/secp256k1.h
+    ${INSTALL_DIR}/include/secp256k1_preallocated.h
+    ${INSTALL_DIR}/include/secp256k1_rangeproof.h
+    ${INSTALL_DIR}/include/secp256k1_recovery.h
+    ${INSTALL_DIR}/include/secp256k1_schnorrsig.h
+    ${INSTALL_DIR}/include/secp256k1_surjectionproof.h
+    ${INSTALL_DIR}/include/secp256k1_whitelist.h
+)
+set_target_properties(libsecp256k1 PROPERTIES
+    IMPORTED_LOCATION ${INSTALL_DIR}/lib/libsecp256k1.a
+    PUBLIC_HEADER "${_secp_public_headers}"
+)
+add_dependencies(libsecp256k1 libsecp256k1-build)
+
+
+install(
+    FILES $<TARGET_PROPERTY:libsecp256k1,IMPORTED_LOCATION>
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libsecp256k1
+)
+install(
+    FILES $<TARGET_PROPERTY:libsecp256k1,PUBLIC_HEADER>
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT libsecp256k1
+)
+install(
+    FILES ${INSTALL_DIR}/lib/pkgconfig/libsecp256k1.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT libsecp256k1
+)
+install(SCRIPT ${CMAKE_SOURCE_DIR}/cmake/libsecp256k1-pkgconfig.cmake
+    COMPONENT libsecp256k1
+)

--- a/_cmake/wallycore-config.cmake.in
+++ b/_cmake/wallycore-config.cmake.in
@@ -1,0 +1,24 @@
+@PACKAGE_INIT@
+
+set_and_check(WALLYCORE_LIB_DIR @PACKAGE_LIB_CMAKE_INSTALL_DIR@)
+
+if("wallycore" IN_LIST wallycore_FIND_COMPONENTS)
+    include(${WALLYCORE_LIB_DIR}/wallycore-targets.cmake)
+    set(wallycore_wallycore_FOUND TRUE)
+endif()
+
+if("libsecp256k1" IN_LIST wallycore_FIND_COMPONENTS)
+    if(TARGET wallycore::libsecp256k1)
+        message(FATAL_ERROR "wallycore::libsecp256k1 already defined")
+    endif()
+    include(FindPkgConfig REQUIRED)
+    set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+    pkg_check_modules(libsecp256k1 REQUIRED IMPORTED_TARGET libsecp256k1)
+    add_library(wallycore::libsecp256k1 ALIAS PkgConfig::libsecp256k1)
+    set(wallycore_libsecp256k1_FOUND TRUE)
+endif()
+
+set(wallycore_COMPONENT_FOUND TRUE)
+
+
+check_required_components(wallycore)

--- a/src/_CMakeLists.txt
+++ b/src/_CMakeLists.txt
@@ -1,0 +1,29 @@
+
+# libwallycore
+add_library(wallycore)
+file(GLOB ccan_srcs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    "ccan/ccan/base64/*.[ch]"
+    "ccan/ccan/build_assert/*.h"
+    "ccan/ccan/compiler/*.h"
+    "ccan/ccan/crypto/sha256/*.[ch]"
+    "ccan/ccan/crypto/sha512/*.[ch]"
+    "ccan/ccan/crypto/ripemd160/*.[ch]"
+    "ccan/ccan/endian/*.h"
+    "ccan/ccan/str/hex/*.[ch]"
+    "ccan/ccan/tap/*.[ch]"
+)
+file(GLOB wallycore_srcs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.[ch]")
+file(GLOB wallycore_public_headers RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/include/*.h")
+
+target_sources(wallycore PRIVATE ${ccan_srcs} ${wallycore_srcs})
+set_target_properties(wallycore PROPERTIES PUBLIC_HEADER "${wallycore_public_headers}")
+target_include_directories(
+    wallycore
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        ${CMAKE_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/ccan
+)


### PR DESCRIPTION
Extending cmake to compile wallycore source files into a native library

- libsecp256k1 is compiled using ExternalProject cmake module
- ccan sources are compiled as OBJECT libraries

This commit also introduces a first draft of the install process where wallycore library and include files are installed together with the libsecp256k1 ones.

cmake target files are also installed, so users can import wallycore library using cmake's find_package tools.
As libsecp256k1 is an automake-based project we massage its .pc to fit the cmake install process
In cmake language, users can now do
```
find_package(wallycore COMPONENTS wallycore libsecp256k1)
```
and then target the libraries as
```
target_link_libraries(<myproject> [PRIVATE|PUBLIC]
    wallycore::wallycore
    wallycore::libsecp256k1
)
```


FYI: @k-matsuzawa 