### PR TITLE
add `-Wno-unused-parameter` to `SWIG_WARN_CFLAGS`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,7 @@ AC_SUBST([NOBUILTIN_CFLAGS])
 
 # SWIG versions vary in generated code quality; skip warnings
 SWIG_WARN_CFLAGS="-fno-strict-aliasing"
+AX_CHECK_COMPILE_FLAG([-Wno-unused-parameter], [SWIG_WARN_CFLAGS="$SWIG_WARN_CFLAGS -Wno-unused-parameter"])
 AX_CHECK_COMPILE_FLAG([-Wno-shadow], [SWIG_WARN_CFLAGS="$SWIG_WARN_CFLAGS -Wno-shadow"])
 AX_CHECK_COMPILE_FLAG([-Wno-missing-field-initializers], [SWIG_WARN_CFLAGS="$SWIG_WARN_CFLAGS -Wno-missing-field-initializers"])
 if echo | "$CC" -dM -E - | grep __clang__ >/dev/null; then


### PR DESCRIPTION
SWIG generates code with unused parameters that trigger hundreds of warnings.