### PR TITLE
add `-version-info` to `LDFLAGS` in shared library builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -191,10 +191,17 @@ libwallycore_la_INCLUDES = \
     include/wally_transaction.h
 
 if SHARED_BUILD_ENABLED
+LT_VER_CURRENT = 1   # increment at every ABI change (whether breaking or non-breaking)
+LT_VER_REVISION = 0  # increment at every release, but reset to 0 at every ABI change
+LT_VER_AGE = 0       # increment at every ABI change, but reset to 0 if breaking
+# The library filename will be "libwallycore.so.$((current-age)).$((age)).$((revision))",
+# and the soname will be "libwallycore.so.$((current-age))".
+# Do NOT try to make the library version-info follow the project release version number!
+# Only follow the rules above, explained more fully at:
+# https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+libwallycore_la_LDFLAGS = -version-info $(LT_VER_CURRENT):$(LT_VER_REVISION):$(LT_VER_AGE)
 if IS_MINGW
-libwallycore_la_LDFLAGS = -no-undefined
-else
-libwallycore_la_LDFLAGS = 
+libwallycore_la_LDFLAGS += -no-undefined
 endif
 endif # SHARED_BUILD_ENABLED
 


### PR DESCRIPTION
version-info is what determines the dotted triplet of numbers trailing the shared library filename. Meticulous maintenance of version-info allows multiple ABI versions of the library to be installed on a system concurrently and also makes obvious when library clients need to be recompiled for a newer ABI (and when no recompilation is necessary).

See: https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html