### PR TITLE
compile all Java classes in one `javac` invocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -358,15 +358,9 @@ else
 fi
 AM_CONDITIONAL([HAVE_JAVA], [test "x$JAVA" != "x"])
 AM_CONDITIONAL([HAVE_JAVAC], [test "x$JAVAC" != "x"])
-if test "x$swig_java" = "xyes"; then
-    if test "x$JAVAC" != "x"; then
-        if test "x$JAVA" != "x"; then
-            # Only run tests if we have java-swig, compiler and interpreter
-            run_java_tests="yes"
-        fi
-    fi
-fi
-AM_CONDITIONAL([RUN_JAVA_TESTS], [test "x$run_java_tests" != "x"])
+AM_CONDITIONAL([RUN_JAVA_TESTS],
+    dnl Only run tests if we have java-swig, compiler and interpreter
+    [test "x$tests" = xyes -a "x$swig_java" = xyes -a -n "$JAVAC" -a -n "$JAVA"])
 JAVAC_TARGET=1.7
 AC_SUBST([JAVAC_TARGET])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,18 +98,15 @@ sjs=swig_java/src
 $(sjs)/$(cblw)/Wally.java: swig_java/swig_java_wrap.c
 	$(AM_V_at)$(top_srcdir)/tools/swigjavapost.sh @GNU_SED@ $(TOOLS_EXTRA_ARGS)
 
-$(sjs)/$(cblw)/Wally.class: $(sjs)/$(cblw)/Wally.java
-	$(AM_V_at)$(JAVAC) -implicit:none -source $(JAVAC_TARGET) -target $(JAVAC_TARGET) -sourcepath $(sjs)/$(cblw)/ $(sjs)/$(cblw)/Wally.java
+JAVA_CLASSES = $(sjs)/$(cblw)/Wally.class
 
 swig_java/wallycore.jar: $(sjs)/$(cblw)/Wally.class
 	$(AM_V_at)$(JAR) cf swig_java/wallycore.jar -C $(sjs) '$(cblw)/Wally$$Obj.class' -C $(sjs) '$(cblw)/Wally.class'
 
-$(sjs)/$(cbt)/%.class: $(sjs)/$(cbt)/%.java swig_java/wallycore.jar
-	$(AM_V_at)$(JAVAC) -implicit:none -source $(JAVAC_TARGET) -target $(JAVAC_TARGET) -sourcepath $(sjs) $(filter %.java,$^)
-
 if HAVE_JAVAC
 all: swig_java/wallycore.jar
 
+if RUN_JAVA_TESTS
 SWIG_JAVA_TEST_DEPS = \
     $(sjs)/$(cbt)/test_bip32.class \
     $(sjs)/$(cbt)/test_descriptor.class \
@@ -122,7 +119,12 @@ SWIG_JAVA_TEST_DEPS += $(sjs)/$(cbt)/test_assets.class \
     $(sjs)/$(cbt)/test_pegs.class
 endif
 
+JAVA_CLASSES += $(SWIG_JAVA_TEST_DEPS)
 all: $(SWIG_JAVA_TEST_DEPS)
+endif # RUN_JAVA_TESTS
+
+$(JAVA_CLASSES) &: $(JAVA_CLASSES:.class=.java)
+	$(AM_V_at)$(JAVAC) -implicit:none -source $(JAVAC_TARGET) -target $(JAVAC_TARGET) -sourcepath $(sjs) $^
 
 JAVA_TEST = @LDPATH_VAR@=.libs $(JAVA) -Djava.library.path=.libs -classpath $(sjs) com.blockstream.test.
 


### PR DESCRIPTION
Starting up a JVM is not a lightweight affair. For this reason, typically all Java source files are compiled by a single invocation of `javac`. Use GNU Make's "grouped targets" feature to specify that all Java class files are produced by a single execution of the recipe. Further, avoid compiling the test classes if tests are disabled.