### PR TITLE
Python linkage enhancements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,13 @@ from setuptools import setup, Extension
 import copy, os, platform, shutil
 import distutils.sysconfig
 
-CONFIGURE_ARGS = ['--disable-shared', '--enable-static', '--with-pic',
+build_shared = os.environ.get('WALLY_ABI_PY_WHEEL_USE_DSO', '').lower() not in ['', '0', 'false', 'no', 'n', 'off']
+if build_shared:
+    CONFIGURE_ARGS = ['--enable-shared', '--disable-static']
+else:
+    CONFIGURE_ARGS = ['--disable-shared', '--enable-static', '--with-pic']
+
+CONFIGURE_ARGS += [
     '--enable-swig-python', '--enable-python-manylinux',
     '--disable-swig-java', '--disable-tests', '--disable-dependency-tracking']
 
@@ -79,8 +85,10 @@ wally_ext = Extension(
     '_wallycore',
     define_macros=define_macros,
     include_dirs=include_dirs,
-    library_dirs=[] if is_windows else ['src/.libs', 'src/secp256k1/.libs'],
-    libraries=[] if is_windows else ['wallycore', 'secp256k1'],
+    library_dirs=[] if is_windows else
+        ['src/.libs'] + ([] if build_shared else ['src/secp256k1/.libs']),
+    libraries=[] if is_windows else
+        ['wallycore'] + ([] if build_shared else ['secp256k1']),
     extra_compile_args=extra_compile_args,
     sources=[
         'src/swig_python/swig_wrap.c',

--- a/setup.py
+++ b/setup.py
@@ -67,12 +67,11 @@ if is_windows:
 include_dirs=[
     './',
     './src',
-    './src/ccan',
     './src/secp256k1/include',
     ]
 if is_windows:
     shutil.copyfile('./src/amalgamation/windows_config/libsecp256k1-config.h', 'src/secp256k1/src/libsecp256k1-config.h')
-    include_dirs = ['./src/amalgamation/windows_config'] + include_dirs
+    include_dirs = ['./src/amalgamation/windows_config'] + include_dirs + ['./src/ccan']
 
 extra_compile_args = ['-flax-vector-conversions']
 
@@ -80,12 +79,16 @@ wally_ext = Extension(
     '_wallycore',
     define_macros=define_macros,
     include_dirs=include_dirs,
+    library_dirs=[] if is_windows else ['src/.libs', 'src/secp256k1/.libs'],
+    libraries=[] if is_windows else ['wallycore', 'secp256k1'],
     extra_compile_args=extra_compile_args,
     sources=[
-        'src/swig_python/swig_wrap.c' if is_windows else 'src/swig_python/swig_python_wrap.c',
+        'src/swig_python/swig_wrap.c',
         'src/amalgamation/combined.c',
         'src/amalgamation/combined_ccan.c',
         'src/amalgamation/combined_ccan2.c',
+        ] if is_windows else [
+        'src/swig_python/swig_python_wrap.c',
         ],
     )
 


### PR DESCRIPTION
* On systems supporting Libtool (i.e., anything but Windows), skip compiling the "amalgamated" sources for the Python module and simply link in the just-built `libwallycore.a` and `libsecp256k1.a`.

* `setup.py`: support optionally building and linking to libwally-core as a dynamic shared object if `WALLY_ABI_PY_WHEEL_USE_DSO=1` is set. Ignored on Windows, where `setup.py` does not build libwally-core.