### PR TITLE
mbed_tls: don't byteswap if HW acceleration is already big endian

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,12 @@ $ brew install swig
 - `--enabled-standard-secp`. Excludes support for features that are unavailable in
    the standard [libsecp256k1 library](https://github.com/bitcoin-core/secp256k1).
 - `--enable-mbed-tls`. Use mbed-tls hashing functions if available. This typically
-   results in faster hashing on embedded platforms such as STM32. Note that the user
-   must define `MBEDTLS_SHA256_ALT` and/or `SOC_SHA_SUPPORT_PARALLEL_ENG` matching the
-   SOC support when compiling the library. (default: no)
+   results in faster hashing via hardware on embedded platforms such as ESP32.
+   Note that the caller must ensure that ``sdkconfig.h`` and ``soc/soc_caps.h``
+   are available when compiling, e.g. by setting the `CFLAGS` environment variable
+   before calling configure.
+   must define/undefine `MBEDTLS_SHA256_ALT`, `SOC_SHA_SUPPORT_PARALLEL_ENG`
+   matching the SOC support when compiling libwally. (default: no)
 - `--enable-coverage`. Enables code coverage (default: no) Note that you will
    need [lcov](http://ltp.sourceforge.net/coverage/lcov.php) installed to
    build with this option enabled and generate coverage reports.

--- a/src/ccan/ccan/crypto/sha256/sha256.h
+++ b/src/ccan/ccan/crypto/sha256/sha256.h
@@ -14,6 +14,11 @@
 
 #ifdef CCAN_CRYPTO_SHA256_USE_MBEDTLS
 #include <mbedtls/sha256.h>
+#include <sdkconfig.h>
+#include <soc/soc_caps.h>
+#ifdef SOC_SHA_SUPPORT_PARALLEL_ENG
+#include <sha256_alt.h>
+#endif
 #endif
 
 /**

--- a/src/ccan/ccan/crypto/sha512/sha512.h
+++ b/src/ccan/ccan/crypto/sha512/sha512.h
@@ -14,6 +14,11 @@
 
 #ifdef CCAN_CRYPTO_SHA512_USE_MBEDTLS
 #include <mbedtls/sha512.h>
+#include <sdkconfig.h>
+#include <soc/soc_caps.h>
+#ifdef SOC_SHA_SUPPORT_PARALLEL_ENG
+#include <sha512_alt.h>
+#endif
 #endif
 
 /**

--- a/src/hmac.c
+++ b/src/hmac.c
@@ -12,7 +12,11 @@
 #define HMAC_FUNCTION hmac_sha256_impl
 #define WALLY_HMAC_FUNCTION wally_hmac_sha256
 #ifdef CCAN_CRYPTO_SHA256_USE_MBEDTLS
+#ifndef CONFIG_MBEDTLS_HARDWARE_SHA
+#define SHA_CTX_BUFF c.MBEDTLS_PRIVATE(buffer)
+#else
 #define SHA_CTX_BUFF c.buffer
+#endif
 #else
 #define SHA_CTX_BUFF buf.u8
 #endif
@@ -28,7 +32,11 @@
 #define WALLY_HMAC_FUNCTION wally_hmac_sha512
 #undef SHA_CTX_BUFF
 #ifdef CCAN_CRYPTO_SHA512_USE_MBEDTLS
+#ifndef CONFIG_MBEDTLS_HARDWARE_SHA
+#define SHA_CTX_BUFF c.MBEDTLS_PRIVATE(buffer)
+#else
 #define SHA_CTX_BUFF c.buffer
+#endif
 #else
 #define SHA_CTX_BUFF buf.u8
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -201,13 +201,23 @@ static void sha256_midstate(struct sha256_ctx *ctx, struct sha256 *res)
     size_t i;
 
 #ifdef CCAN_CRYPTO_SHA256_USE_MBEDTLS
+#ifndef CONFIG_MBEDTLS_HARDWARE_SHA
+#define SHA_CTX_STATE c.MBEDTLS_PRIVATE(state)
+#else
 #define SHA_CTX_STATE c.state
+#endif
 #else
 #define SHA_CTX_STATE s
 #endif
 
+#if defined(CCAN_CRYPTO_SHA256_USE_MBEDTLS) && \
+    defined(MBEDTLS_SHA256_ALT) && !defined(SOC_SHA_SUPPORT_PARALLEL_ENG)
+    /* HW: Already big endian */
+    memcpy(res->u.u32, ctx->SHA_CTX_STATE, sizeof(ctx->SHA_CTX_STATE));
+#else
     for (i = 0; i < sizeof(ctx->SHA_CTX_STATE) / sizeof(ctx->SHA_CTX_STATE[0]); i++)
         res->u.u32[i] = cpu_to_be32(ctx->SHA_CTX_STATE[i]);
+#endif
 
 #ifndef CCAN_CRYPTO_SHA256_USE_MBEDTLS
     ctx->bytes = (size_t)-1;
@@ -225,11 +235,6 @@ int wally_sha256_midstate(const unsigned char *bytes, size_t bytes_len,
         return WALLY_EINVAL;
 
     sha256_init(&ctx);
-#if defined(CCAN_CRYPTO_SHA256_USE_MBEDTLS) && \
-    defined(MBEDTLS_SHA256_ALT) && defined(SOC_SHA_SUPPORT_PARALLEL_ENG)
-    /* HW sha engine doesn't allow to extract the midstate */
-    ctx.c.mode = ESP_MBEDTLS_SHA256_SOFTWARE;
-#endif
     sha256_update(&ctx, bytes, bytes_len);
     sha256_midstate(&ctx, aligned ? (void *)bytes_out : (void *)&sha);
     wally_clear(&ctx, sizeof(ctx));


### PR DESCRIPTION
Tested on:

esp32:
- vanilla wally without mbed
- wally with mbed with acceleration off
- wally with mbed with acceleration on

esp32s3:
- vanilla wally without mbed
- wally with mbed with acceleration off
- wally with mbed with acceleration on

should also work on esp32s2, esp32c3, esp32c6, esp32p4, etc

Please note:

There's 4 implementations: software, parallel engine, block engine, dma

SOC_SHA_SUPPORT_PARALLEL_ENG is only defined for esp32. esp32s3 uses DMA

SOC_SHA_ENDIANNESS_BE is not available in release branches, only in master and only for esp32 AFAIK

example of how idf checks for things https://github.com/espressif/esp-idf/blob/master/components/mbedtls/port/sha/esp_sha.c#L19

We depend on `#include <soc/soc_caps.h>` to get SOC_SHA_SUPPORT_PARALLEL_ENG (which wasn't available to wally before!!!) and we depend on `#include <sdkconfig.h> to get CONFIG_MBEDTLS_HARDWARE_SHA which is necessary to distinguish between mbedtls with or without hw acceleration.

instead of including sdkconfig.h (and or soc_caps.h) we could have other flags like `HAVE_MBEDTLS_SHA256_H` and `HAVE_MBEDTLS_SHA512_H`