### PR TITLE
tx: check absolute tx limits only when constructing from scratch

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install MSVC
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1.4.1
+        uses: ilammy/msvc-dev-cmd@v1.13.0
 
       - name: Install qemu aarch64
         if: runner.os == 'Linux'

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -1154,7 +1154,7 @@ static int psbt_init(uint32_t version, size_t num_inputs, size_t num_outputs,
     if ((version != PSBT_0 && version != PSBT_2) || !psbt_out)
         return WALLY_EINVAL; /* Only v0/v2 are specified/supported */
     if (num_inputs > TX_MAX_INPUTS || num_outputs > TX_MAX_OUTPUTS)
-        return WALLY_EINVAL; /* Resulting tx could not fit in a block */
+        return WALLY_EINVAL; /* Resulting tx would be non-standard */
 #ifdef BUILD_ELEMENTS
     if (flags & ~WALLY_PSBT_INIT_PSET ||
         (flags & WALLY_PSBT_INIT_PSET && version != PSBT_2))

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -1162,9 +1162,6 @@ static int tx_init_alloc(uint32_t version, uint32_t locktime,
     struct wally_tx_output *new_outputs = NULL;
 
     OUTPUT_CHECK;
-    if (inputs_allocation_len > TX_MAX_INPUTS ||
-        outputs_allocation_len > TX_MAX_OUTPUTS)
-        return WALLY_EINVAL; /* Tx cannot fit in a block: invalid */
     OUTPUT_ALLOC(struct wally_tx);
 
     if (inputs_allocation_len) {
@@ -1202,6 +1199,9 @@ int wally_tx_init_alloc(uint32_t version, uint32_t locktime,
                         size_t outputs_allocation_len,
                         struct wally_tx **output)
 {
+    if (inputs_allocation_len > TX_MAX_INPUTS ||
+        outputs_allocation_len > TX_MAX_OUTPUTS)
+        return WALLY_EINVAL; /* Non-standard tx: invalid */
     return tx_init_alloc(version, locktime,
                          inputs_allocation_len, outputs_allocation_len,
                          TX_MAX_INPUTS_ALLOC, TX_MAX_OUTPUTS_ALLOC, output);


### PR DESCRIPTION
Allow as many inputs/outputs as are present if we are building a tx from its serialized bytes. Since we fully analyze the tx before building it, we know that it can fit in memory/is not impossible to create for DOS checking purposes. This allows us to process live txs such as a recent testnet tx with ~100k outputs.

We retain the limit on constructing new txs from scratch, since wally is meant only for making txs that fit within standardness rules. This catches cases where a tx is constructed in parts or allocated up front based on an externally provided number of inputs/ouputs.

Update the comments to reflect that the limits are for standardness and not block size.