### PR TITLE
wally_scriptpubkey_get_type: only check 1st byte for OP_RETURN scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+### Fixed
+- wally_scriptpubkey_get_type: mark all scripts starting with OP_RETURN as
+  WALLY_SCRIPT_TYPE_OP_RETURN.
+
 ## Version 1.2.0
 
 ### Added

--- a/src/script.c
+++ b/src/script.c
@@ -299,12 +299,7 @@ size_t confidential_value_to_bytes(const unsigned char *bytes, size_t bytes_len,
 
 static bool scriptpubkey_is_op_return(const unsigned char *bytes, size_t bytes_len)
 {
-    size_t n_op, n_push;
-
-    return bytes_len && bytes[0] == OP_RETURN &&
-           get_push_size(bytes + 1, bytes_len - 1, true, &n_op) == WALLY_OK &&
-           get_push_size(bytes + 1, bytes_len - 1, false, &n_push) == WALLY_OK &&
-           bytes_len == 1 + n_op + n_push;
+    return bytes_len && bytes[0] == OP_RETURN;
 }
 
 static bool scriptpubkey_is_p2pkh(const unsigned char *bytes, size_t bytes_len)

--- a/src/test/test_script.py
+++ b/src/test/test_script.py
@@ -95,6 +95,16 @@ class ScriptTests(unittest.TestCase):
             ret = wally_scriptpubkey_get_type(out, ret[1])
             self.assertEqual(ret, (WALLY_OK, SCRIPT_TYPE_OP_RETURN))
 
+        # Some scripts are considered op_return but they cannot be created with
+        # wally_scriptpubkey_op_return_from_bytes and they might not be standard
+        for script_hex in [
+            '6a',
+            '6a6a',
+        ]:
+            script, script_len = make_cbuffer(script_hex)
+            ret, typ = wally_scriptpubkey_get_type(script, script_len)
+            self.assertEqual((ret, typ), (WALLY_OK, SCRIPT_TYPE_OP_RETURN))
+
     def test_scriptpubkey_p2pkh_from_bytes(self):
         """Tests for creating p2pkh scriptPubKeys"""
         # Invalid args


### PR DESCRIPTION
Even though a script might not be created with
`wally_scriptpubkey_op_return_from_bytes` (e.g. `<OP_RETURN>`) or it is not standard (e.g. `<OP_RETURN OP_RETURN>`), if it's starting with `OP_RETURN`, it should still be considered a `OP_RETURN` script.

Bitcoin Core checks [1]
```
    bool IsUnspendable() const
    {
        return (size() > 0 && *begin() == OP_RETURN) || (size() > MAX_SCRIPT_SIZE);
    }
```

rust-bitcoin does [2]
```
    pub fn is_op_return(&self) -> bool {
        match self.0.first() {
            Some(b) => *b == OP_RETURN.to_u8(),
            None => false,
        }
    }
```

----
[1] https://github.com/bitcoin/bitcoin/blob/d04324a7056a735c1127ba8ccdc720a16e7281a3/src/script/script.h#L552-L555

[2] https://github.com/rust-bitcoin/rust-bitcoin/blob/9df59639cec214bd9363d426335923611a304119/bitcoin/src/blockdata/script/borrowed.rs#L350-L354