### PR TITLE
PSET: Allow proof generation for PSET inputs without witness UTXOs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ### Fixed
 - psbt_sign_bip32: Fix signing with parent/master keys. Only already-derived
   keys would result in signed inputs previously.
+- PSET: Allow generating explicit proofs for inputs with only a non-witness UTXO.
 - wally_scriptpubkey_get_type: Mark all scripts starting with OP_RETURN as
   WALLY_SCRIPT_TYPE_OP_RETURN.
 

--- a/include/wally_psbt.h
+++ b/include/wally_psbt.h
@@ -1230,7 +1230,7 @@ WALLY_CORE_API int wally_psbt_input_clear_utxo_rangeproof(
     struct wally_psbt_input *input);
 
 /**
- * Generate explicit proofs and unblinded values from an inputs witness UTXO.
+ * Generate explicit proofs and unblinded values from an inputs UTXO.
  *
  * :param input: The input to generate proofs for.
  * :param satoshi: The explicit value of the input.
@@ -1245,6 +1245,9 @@ WALLY_CORE_API int wally_psbt_input_clear_utxo_rangeproof(
  *
  * .. note:: This function exposes the unblinded asset and value in the PSET,
  *           which is only appropriate in certain multi-party protocols.
+ * .. note:: This function can only be called on v2 PSETs. It is strongly
+ *           recommended to use `wally_psbt_generate_input_explicit_proofs`
+ *           which ensures this, instead of this function.
  */
 WALLY_CORE_API int wally_psbt_input_generate_explicit_proofs(
     struct wally_psbt_input *input,

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -5271,6 +5271,8 @@ int wally_psbt_is_elements(const struct wally_psbt *psbt, size_t *written)
         return WALLY_EINVAL;
 
     *written = memcmp(psbt->magic, PSET_MAGIC, sizeof(PSET_MAGIC)) ? 0 : 1;
+    if (*written && psbt->version != PSBT_2)
+        return WALLY_EINVAL; /* PSET must be v2 */
     return WALLY_OK;
 }
 


### PR DESCRIPTION
Following this change, wally is able to generate proofs even if only a non-witness UTXO is present.