### PR TITLE
Docker: remove default

### DIFF
--- a/contrib/Dockerfile_bullseye
+++ b/contrib/Dockerfile_bullseye
@@ -7,7 +7,7 @@ FROM debian:bullseye@sha256:01559430c84e6bc864bed554345d1bfbfa94ac108ab68f39915c
 WORKDIR /root
 COPY bullseye_deps.sh ./deps.sh
 COPY requirements.txt ./contrib/requirements.txt
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-${TARGETARCH}
 RUN ./deps.sh && rm ./deps.sh


### PR DESCRIPTION
I noticed that the ARM build was using amd64 as folder, this was fixed after removing the default value here.