### PR TITLE
Misc cleanups, add rawtr()/tr(k) descriptor support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # libwally-core documentation build configuration file
+from os import getenv
+
 SCANNING, DOCS, FUNC = 1, 2, 3
 
-from os import getenv
 # DUMP_FUNCS/DUMP_INTERNAL are used by tools/build_wrappers.py to auto-generate wrapper code
 DUMP_FUNCS = getenv("WALLY_DOC_DUMP_FUNCS") is not None
 DUMP_INTERNAL = DUMP_FUNCS and getenv("WALLY_DOC_DUMP_INTERNAL") is not None

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 """setuptools config for wallycore """
 from setuptools import setup, Extension
-import copy, os, platform, shutil, subprocess, sys
+import copy
 import distutils.sysconfig
+import os
+import platform
+import subprocess
+import sys
 
 def _msg(s):
     print(s + '\n', file=sys.stderr)

--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -384,6 +384,18 @@ static const struct descriptor_test {
         "5120b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e",
         "ha989syu"
     },{
+        "descriptor - tr - x-only",
+        "tr(x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
+        "51205fb8e39dbbdc7c831af59e44a9b2997f9daaf72c3e965b30982f3c731539e1db",
+        "axny68jy"
+    },{
+        "descriptor - tr - non-x-only returns the same script as x-only",
+        "tr(non_x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
+        "51205fb8e39dbbdc7c831af59e44a9b2997f9daaf72c3e965b30982f3c731539e1db",
+        "tp2ky708"
+    },{
         "descriptor - A single key",
         "wsh(c:pk_k(key_1))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
@@ -1294,6 +1306,26 @@ static const struct descriptor_test {
         "rawtr(uncompresseduncompressed)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
     },{
+        "descriptor - empty tr",
+        "tr()",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - tr - multi-child",
+        "tr(x_only,x_only)", /* FIXME: delete this case when script path is supported */
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - tr - any parent",
+        "pk(tr(x_only))",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - tr - uncompressed key",
+        "tr(uncompressed)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - tr - invalid public key",
+        "tr(uncompresseduncompressed)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
         "descriptor - after - non number child",
         "wsh(after(key_1))",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
@@ -1791,6 +1823,24 @@ static const struct address_test {
             "bcrt1phmq09p8y6efk06fp5hvf6dkvjsq2vfmph2uuy7y6ya6jvmrfxq3s44cksv",
             "bcrt1p9s6clznyy4enaplm2ak9fa0t3d66s5q5m4khpg7w00w9wuerp93q88e9ql",
             "bcrt1p220y7newnya8fk04079hcvd3cupx6t8ta659nayh8kaav39f3scsf63y8h",
+        }
+    }, {
+        "address - tr (x-only)",
+        "tr(x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST,
+        0, 0, 0,
+        ADDR("bcrt1pt7uw88dmm37gxxh4nez2nv5e07w64aev86t9kvyc9u78x9feu8dsp5hh3s")
+    }, {
+        "address list - tr (5-9)",
+        "tr([59d1f3b0/86'/1'/0']tpubDC2Q4xK4XH72Gow34bNSZpx7uPcg1gfu6hPACSSieETYzpWgywMLmi2Yz9STA2Nrif3Yav7jvkzSj8q3nDKjjQrEfRYckUj5jsadYCdCw1C/0/*)#9wpuzyss",
+        WALLY_NETWORK_BITCOIN_REGTEST,
+        0, 0, 5, 5,
+        {
+            "bcrt1p3hf8e9tczepujy3fe66wgq9ez5tllqkschupy08pfzukjtye5wksgtj5k2",
+            "bcrt1p9wut0rvmq347rldeyktdn9qmrj9qk9ynefykruxrp4yr9u27pzvqfd6ktq",
+            "bcrt1p3kjmw33umzaylvdmglk489vd4ph2te67ged3c4fmk20adn0pfknsm5jmvu",
+            "bcrt1pz6t2y0qg69594u60qmnlq23rezxseyf65qk0xl2kt7l02y8rcs8qndm2sm",
+            "bcrt1p2nunl5trs2hfrlu5fp6kg3hu3tffpzg0w5m56mpmx8m96pl0qxnszgdnaw",
         }
     },
     /*

--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -372,6 +372,18 @@ static const struct descriptor_test {
         "76a91477b6f27ac523d8b9aa8abcfc94fd536493202ae088ac",
         "9gv5p2gj"
     },{
+        "descriptor - rawtr - x-only",
+        "rawtr(x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
+        "5120b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e",
+        "nsnjmrf4"
+    },{
+        "descriptor - rawtr - non-x-only returns the same script as x-only",
+        "rawtr(non_x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
+        "5120b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e",
+        "ha989syu"
+    },{
         "descriptor - A single key",
         "wsh(c:pk_k(key_1))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
@@ -1758,6 +1770,28 @@ static const struct address_test {
         WALLY_NETWORK_BITCOIN_REGTEST,
         1, 0, 0,
         ADDR("mn9rm3FtHUHANae2p5jURy9GXJGDM1ox43")
+    },
+    /*
+     * Taproot
+     */
+    {
+        "address - rawtr (x-only)",
+        "rawtr(x_only)",
+        WALLY_NETWORK_BITCOIN_REGTEST,
+        0, 0, 0,
+        ADDR("bcrt1pkud2089tpt3dswuz63xtms3lthx2x7t73wnz938yt28hmn3ghg8qvxhwkz")
+    }, {
+        "address list - rawtr (0-4)",
+        "rawtr([59d1f3b0/86'/1'/0']tpubDC2Q4xK4XH72Gow34bNSZpx7uPcg1gfu6hPACSSieETYzpWgywMLmi2Yz9STA2Nrif3Yav7jvkzSj8q3nDKjjQrEfRYckUj5jsadYCdCw1C/0/*)#2k4we0vv",
+        WALLY_NETWORK_BITCOIN_REGTEST,
+        0, 0, 0, 5,
+        {
+            "bcrt1p7evqsttltmzxd4sjyzhdzs5nj8tmahu0qdpge8t7gp3dsr3hx3dq403ahy",
+            "bcrt1pa76letfw4eskpz9wap84ha0vcajul7xhhnhktmpp0mhgzlcdr6gswjcq3u",
+            "bcrt1phmq09p8y6efk06fp5hvf6dkvjsq2vfmph2uuy7y6ya6jvmrfxq3s44cksv",
+            "bcrt1p9s6clznyy4enaplm2ak9fa0t3d66s5q5m4khpg7w00w9wuerp93q88e9ql",
+            "bcrt1p220y7newnya8fk04079hcvd3cupx6t8ta659nayh8kaav39f3scsf63y8h",
+        }
     },
     /*
      * Multi-path

--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -42,6 +42,8 @@ static struct wally_map_item g_key_map_items[] = {
     { B("mainnet_xpub"), B("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL") },
     { B("mainnet_xpriv"), B("xprvA2YKGLieCs6cWCiczALiH1jzk3VCCS5M1pGQfWPkamCdR9UpBgE2Gb8AKAyVjKHkz8v37avcfRjdcnP19dVAmZrvZQfvTcXXSAiFNQ6tTtU") },
     { B("uncompressed"), B("0414fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267be5645686309c6e6736dbd93940707cc9143d3cf29f1b877ff340e2cb2d259cf") },
+    { B("x_only"), B("b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e") },
+    { B("non_x_only"), B("03b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e") }
 };
 
 static const struct wally_map g_key_map = {
@@ -897,7 +899,7 @@ static const struct descriptor_test {
         "d959hk4q"
     },
     /*
-     * Taproot cases
+     * Miniscript taproot cases
      */
     {
         "miniscript - taproot raw pubkey",
@@ -1140,6 +1142,14 @@ static const struct descriptor_test {
         "pk(1)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
     },{
+        "descriptor - pk - invalid public key",
+        "pk(uncompresseduncompressed)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - pk - x-only child",
+        "pk(x_only)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
         "descriptor - pk - multi-child",
         "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
@@ -1250,6 +1260,26 @@ static const struct descriptor_test {
     },{
         "descriptor - raw - any parent",
         "pk(raw(000102030405060708090a0b0c0d0e0f))",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - empty rawtr",
+        "rawtr()",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - rawtr - multi-child",
+        "rawtr(x_only,x_only)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - rawtr - any parent",
+        "pk(rawtr(x_only))",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - rawtr - uncompressed key",
+        "rawtr(uncompressed)",
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+    },{
+        "descriptor - rawtr - invalid public key",
+        "rawtr(uncompresseduncompressed)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
     },{
         "descriptor - after - non number child",

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -2546,8 +2546,12 @@ static int node_generation_size(const ms_node *node, size_t *total)
             /* max of p2pk, p2pkh, p2wpkh, or p2sh-p2wpkh */
             *total += WALLY_SCRIPTPUBKEY_P2PKH_LEN;
             break;
-        case KIND_DESCRIPTOR_ADDR:
         case KIND_DESCRIPTOR_RAW:
+            /* Add an extra byte to handle 'raw()' which results in nothing,
+             * as empty output buffers cannot be passed to descriptor calls.
+             */
+            *total += 1;
+        case KIND_DESCRIPTOR_ADDR:
             /* No-op */
             break;
         case KIND_DESCRIPTOR_RAW_TR:

--- a/src/pullpush.c
+++ b/src/pullpush.c
@@ -149,8 +149,12 @@ uint64_t pull_varint(const unsigned char **cursor, size_t *max)
     uint64_t v;
 
     pull_bytes(buf, 1, cursor, max);
+    if (!*cursor)
+        return 0;
     if ((len = varint_length_from_bytes(buf) - 1))
         pull_bytes(buf + 1, len, cursor, max);
+    if (!*cursor)
+        return 0;
     varint_from_bytes(buf, &v);
     return v;
 }

--- a/src/swig_python/contrib/elements_tx.py
+++ b/src/swig_python/contrib/elements_tx.py
@@ -86,8 +86,8 @@ class ElementsTxTests(unittest.TestCase):
         tx_add_output(tx, tx_output)
         ct_value = tx_confidential_value_from_satoshi(20000)
         tx_add_elements_raw_output(tx, script, None, ct_value, None, None, None, 0)
-        size = tx_get_length(tx, 0)
-        vsize = tx_vsize_from_weight(tx_get_weight(tx))
+        tx_get_length(tx, 0)
+        tx_vsize_from_weight(tx_get_weight(tx))
         for extra_flags in (0, WALLY_TX_FLAG_USE_ELEMENTS, WALLY_TX_FLAG_ALLOW_PARTIAL):
             tx_hex = tx_to_hex(tx, WALLY_TX_FLAG_USE_WITNESS | extra_flags)
             tx_bytes = tx_to_bytes(tx, WALLY_TX_FLAG_USE_WITNESS | extra_flags)

--- a/src/swig_python/contrib/mnemonic.py
+++ b/src/swig_python/contrib/mnemonic.py
@@ -50,12 +50,12 @@ if __name__ == "__main__":
         try:
             m.generate(BIP39_ENTROPY_LEN_256 - 1)
             assert False
-        except:
+        except Exception as _:
             pass
         try:
             m.check(phrase + ' foo')
             assert False
-        except:
+        except Exception as _:
             pass
         assert m.to_entropy(phrase) == m.to_entropy(phrase.split())
         assert m.to_mnemonic(m.to_entropy(phrase)) == phrase

--- a/src/swig_python/contrib/psbt.py
+++ b/src/swig_python/contrib/psbt.py
@@ -150,7 +150,7 @@ class PSBTTests(unittest.TestCase):
             asset = hex_to_bytes('77' * 32)
             explicit_asset = hex_to_bytes('01' + '77' * 32)
             blinded_asset = hex_to_bytes('0a' + '77' * 32) # Dummy value
-            explicit_value = tx_confidential_value_from_satoshi(1234)
+            explicit_value = tx_confidential_value_from_satoshi(value)
             blinded_value = hex_to_bytes('08' + '55' * 32) # Dummy value
 
         # Inputs: BTC
@@ -166,9 +166,9 @@ class PSBTTests(unittest.TestCase):
 
         # Outputs: BTC
         psbt2 = psbt_init(2, 0, 0, 0, 0)
-        tx_output = tx_output_init(1234, script)
+        tx_output = tx_output_init(value, script)
         psbt_add_tx_output_at(psbt2, 0, 0, tx_output)
-        self.assertEqual(psbt_get_output_amount(psbt2, 0), 1234)
+        self.assertEqual(psbt_get_output_amount(psbt2, 0), value)
         self.assertEqual(psbt_get_output_script(psbt2, 0), script)
 
         if is_elements_build():
@@ -180,7 +180,7 @@ class PSBTTests(unittest.TestCase):
             # txout has explicit value/asset: Expect the values
             # set and no commitments in the PSET
             self.assertEqual(psbt_has_output_amount(pset2, 0), 1)
-            self.assertEqual(psbt_get_output_amount(pset2, 0), 1234)
+            self.assertEqual(psbt_get_output_amount(pset2, 0), value)
             self.assertEqual(psbt_get_output_value_commitment_len(pset2, 0), 0)
             self.assertTrue(not psbt_get_output_value_commitment(pset2, 0))
             self.assertEqual(psbt_get_output_script(pset2, 0), script)
@@ -339,7 +339,6 @@ class PSBTTests(unittest.TestCase):
         dummy_tap_internal_key = bytearray(b'\x01' * 32) # Untweaked x-only pubkey
         if is_elements_build():
             dummy_nonce = bytearray(b'\x00' * WALLY_TX_ASSET_CT_NONCE_LEN)
-            dummy_bf = bytearray(b'\x00' * BLINDING_FACTOR_LEN)
             dummy_blind_asset = bytearray(b'\x0a' * ASSET_COMMITMENT_LEN)
             dummy_blind_value = bytearray(b'\x08' * WALLY_TX_ASSET_CT_VALUE_UNBLIND_LEN)
             dummy_nonce = bytearray(b'\x02' * ASSET_COMMITMENT_LEN)

--- a/src/swig_python/contrib/reconcile_sigs.py
+++ b/src/swig_python/contrib/reconcile_sigs.py
@@ -8,12 +8,11 @@ try:
 except ImportError:
     have_pycoin = False
 
-USE_WITNESS = 1
 
 class TxTests(unittest.TestCase):
 
     def do_test_tx(self, sighash, index_, flags):
-        txhash, seq, script, witness_script = b'0' * 32, 0xffffffff, b'\x51', b'000000'
+        txhash, seq, script = b'0' * 32, 0xffffffff, b'\x51'
         out_script, spend_script, locktime = b'\x00\x00\x51', b'\x00\x51', 999999
         txs_in = [TxIn(txhash, 0, script, seq),
                   TxIn(txhash, 1, script+b'\x51', seq-1),
@@ -29,7 +28,7 @@ class TxTests(unittest.TestCase):
                          3: TxOut(5003, spend_script)}
         unspent = pytx.unspents[index_]
         pytx_hex = pytx.as_hex()
-        if flags & USE_WITNESS:
+        if flags & WALLY_TX_FLAG_USE_WITNESS:
             pytx_hash = pytx.signature_for_hash_type_segwit(unspent.script, index_, sighash)
         else:
             pytx_hash = pytx.signature_hash(spend_script, index_, sighash)
@@ -44,7 +43,6 @@ class TxTests(unittest.TestCase):
         tx_add_raw_output(tx, 54, out_script+b'\x51', 0)
         tx_add_raw_output(tx, 53, out_script+b'\x51\x51', 0)
         tx_hex = tx_to_hex(tx, 0)
-        amount = (index_ + 1) * 5000
         tx_hash = tx_get_btc_signature_hash(tx, index_,
                                             unspent.script, unspent.coin_value,
                                             sighash, flags)
@@ -57,7 +55,7 @@ class TxTests(unittest.TestCase):
         for sighash in [WALLY_SIGHASH_ALL, WALLY_SIGHASH_NONE, WALLY_SIGHASH_SINGLE]:
             for index_ in [0, 1, 2, 3]:
                 for anyonecanpay in [0, WALLY_SIGHASH_ANYONECANPAY]:
-                    for flags in [0, USE_WITNESS]:
+                    for flags in [0, WALLY_TX_FLAG_USE_WITNESS]:
                         self.do_test_tx(sighash | anyonecanpay, index_, flags)
 
 

--- a/src/swig_python/contrib/signmessage.py
+++ b/src/swig_python/contrib/signmessage.py
@@ -27,9 +27,10 @@ class SignMessageTest(unittest.TestCase):
         message = 'This is just a test message'.encode('ascii')
         priv_key_wif = 'cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N'
         address = 'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB'
-        expected_signature = 'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0=' 
+        expected_signature = b'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0='
 
         signature = self.signmessage(priv_key_wif, message)
+        self.assertEqual(signature, expected_signature)
         self.assertTrue(self.verifymessage(address, signature, message))
 
 

--- a/src/swig_python/contrib/tx.py
+++ b/src/swig_python/contrib/tx.py
@@ -19,7 +19,7 @@ class TxTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             tx_witness_stack_clone(None)
-        cloned = tx_witness_stack_clone(witness)
+        tx_witness_stack_clone(witness)
 
     def test_tx_input(self):
         # Test invalid inputs
@@ -101,9 +101,9 @@ class TxTests(unittest.TestCase):
         self.assertEqual(tx_get_total_output_satoshi(tx), 10000)
         tx_add_raw_output(tx, 20000, script, 0)
         self.assertEqual(tx_get_total_output_satoshi(tx), 30000)
-        size = tx_get_length(tx, 0)
-        vsize = tx_vsize_from_weight(tx_get_weight(tx))
-        tx_hex = tx_to_hex(tx, FLAG_USE_WITNESS)
+        tx_get_length(tx, 0)
+        tx_vsize_from_weight(tx_get_weight(tx))
+        tx_to_hex(tx, FLAG_USE_WITNESS)
 
         with self.assertRaises(ValueError):
             tx_add_raw_output(tx, WALLY_SATOSHI_MAX + 1, script, 0)

--- a/src/test/test_aes.py
+++ b/src/test/test_aes.py
@@ -93,7 +93,7 @@ class AESTests(unittest.TestCase):
                 self.assertEqual(h(out_buf), h(o))
 
     def test_aes_cbc_with_ecdh_key(self):
-        ENCRYPT, DECRYPT, PUBKEY_LEN, _ = 1, 2, 33, True
+        ENCRYPT, DECRYPT, _ = 1, 2, True
         a_priv = make_cbuffer('1c6a837d1ac663fdc7f1002327ca38452766eaf4fe3b80ce620bf7cd3f584cf6')[0]
         a_pub = make_cbuffer('03e581be89d1ef8ce11d60746d08e4f8aedf934d1d861dd436042ee2e3b16db918')[0]
         b_priv = make_cbuffer('0b6b3dc90d203d854100110788ac87d43aa00620c9cdb361b281b09022ef4b53')[0]

--- a/src/test/test_anti_exfil.py
+++ b/src/test/test_anti_exfil.py
@@ -16,7 +16,7 @@ class AntiExfilTests(unittest.TestCase):
 
         flags = FLAG_ECDSA
 
-        ret = wally_ec_public_key_from_private_key(priv_key, 32, pub_key, 33);
+        ret = wally_ec_public_key_from_private_key(priv_key, 32, pub_key, 33)
         self.assertEqual(WALLY_OK, ret)
 
         ret = wally_ae_host_commit_from_bytes(entropy, 32, flags, host_commitment, 32)

--- a/src/test/test_elements.py
+++ b/src/test/test_elements.py
@@ -202,7 +202,7 @@ class ElementsTests(unittest.TestCase):
         SCALAR_OFFSET_LEN = 32
         offset, offset_len = make_cbuffer('00' * SCALAR_OFFSET_LEN)
         ret = wally_asset_scalar_offset(value, UNBLINDED_ABF, UNBLINDED_ABF_LEN,
-                                        UNBLINDED_VBF, UNBLINDED_VBF_LEN, offset, offset_len);
+                                        UNBLINDED_VBF, UNBLINDED_VBF_LEN, offset, offset_len)
         self.assertEqual(ret, WALLY_OK)
         self.assertEqual(h(offset),
                          utf8('4e5f3ca8aa2048eeacc8c300e3d63ca92048f407264352bee2fb15bd44349c45'))

--- a/src/test/test_map.py
+++ b/src/test/test_map.py
@@ -162,7 +162,7 @@ class MapTests(unittest.TestCase):
         self.assertEqual(wally_map_find(clone, new_key, new_key_len), (WALLY_OK, 0))
 
         # Re-create clone to test combining
-        self.assertEqual(wally_map_free(clone), WALLY_OK);
+        self.assertEqual(wally_map_free(clone), WALLY_OK)
         self.assertEqual(wally_map_init_alloc(0, None, clone), WALLY_OK)
         self.assertEqual(wally_map_add(clone, new_key, new_key_len, v, vl), WALLY_OK)
 
@@ -246,7 +246,7 @@ class MapTests(unittest.TestCase):
         self.assertEqual(wally_map_add(m, bip32, bip32_len, kp_path, len(kp_path)), WALLY_OK)
 
         # Fingerprint/Path
-        out, out_len = (c_ubyte * (FP_LEN + 5 * 4))(), 24
+        out = (c_ubyte * (FP_LEN + 5 * 4))()
         cases = [
             (None,  0, out,  FP_LEN),   # NULL key
             (m,     1, out,  FP_LEN),   # Bad index
@@ -255,7 +255,6 @@ class MapTests(unittest.TestCase):
         ]
         for args in cases:
             self.assertEqual(wally_map_keypath_get_item_fingerprint(*args), WALLY_EINVAL)
-            plen = out_len - 4 if args[3] == FP_LEN else out_len - 5
             if args[0] is None or args[1] != 0:
                 ret = wally_map_keypath_get_item_path_len(args[0], args[1])
                 self.assertEqual(ret, (WALLY_EINVAL, 0))

--- a/src/test/test_sign.py
+++ b/src/test/test_sign.py
@@ -188,7 +188,7 @@ class SignTests(unittest.TestCase):
                  (priv_key, len(priv_key),   out_buf, 10)]           # Wrong out len
 
         for pk, pk_len, o, o_len in cases:
-            ret = wally_ec_public_key_from_private_key(pk, pk_len, o, o_len);
+            ret = wally_ec_public_key_from_private_key(pk, pk_len, o, o_len)
             self.assertEqual(ret, WALLY_EINVAL)
 
 

--- a/src/test/test_transaction.py
+++ b/src/test/test_transaction.py
@@ -484,7 +484,6 @@ class TransactionTests(unittest.TestCase):
             annex = None
             annex_len = 0
 
-            fn = wally_tx_get_btc_taproot_signature_hash
             args = [tx, index, scripts, values, num_values, tapleaf_script, tapleaf_script_len,
                     key_version, codesep_pos, annex, annex_len, sighash, flags, bytes_out, out_len]
 

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -3,7 +3,6 @@ from binascii import hexlify, unhexlify
 from os.path import isfile, abspath
 from os import urandom
 import platform
-import sys
 
 # Allow to run from any sub dir
 SO_EXT = 'dylib' if platform.system() == 'Darwin' else 'dll' if platform.system() == 'Windows' else 'so'

--- a/tools/build_wrappers.py
+++ b/tools/build_wrappers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import subprocess
-import sys
 
 # Structs with no definition in the public header files
 OPAQUE_STRUCTS = [u'words', u'wally_descriptor']
@@ -338,9 +337,9 @@ def gen_wally_hpp(funcs, all_funcs):
             prev = func.args[-3]
             impl.append(f'    if (ret == WALLY_OK && n != static_cast<size_t>({prev.name}.size())) ret = WALLY_EINVAL;')
         if is_verify_function:
-            impl.append(f'    return ret == WALLY_OK;')
+            impl.append('    return ret == WALLY_OK;')
         else:
-            impl.append(f'    return detail::check_ret(__FUNCTION__, ret);')
+            impl.append('    return detail::check_ret(__FUNCTION__, ret);')
         impl.extend([u'}', u''])
         (cpp_elements if func.is_elements else cpp)[func.name] = impl
 
@@ -490,8 +489,10 @@ def gen_wasm_package(funcs, all_funcs):
 
                 js_args.append(js_arg_type)
 
-                if ts_arg_type:    ts_args.append(f'{arg.name}: {ts_arg_type}')
-                if ts_return_type: ts_returns.append(f'{arg.name}: {ts_return_type}')
+                if ts_arg_type:
+                    ts_args.append(f'{arg.name}: {ts_arg_type}')
+                if ts_return_type:
+                    ts_returns.append(f'{arg.name}: {ts_return_type}')
 
                 continue
 

--- a/tools/wordlist_cc.py
+++ b/tools/wordlist_cc.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         assert len(words) >= 2
         assert len(words) in bits
 
-        lengths = [ 0 ];
+        lengths = [ 0 ]
         for w in words:
             lengths.append(lengths[-1] + len(w.encode('utf-8')) + 1)
         idxs = ['{0}+{1}'.format(string_name, n) for n in lengths]


### PR DESCRIPTION
Adds `rawtr()` and `tr(k)` initially, as the simplest of the taproot descriptor cases.

`tr(k,script)` will be added in a future MR.