### PR TITLE
Update pre-segwit signature hashing to use the new caching implementation

### DIFF
--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -772,6 +772,9 @@ WALLY_CORE_API int wally_tx_get_total_output_satoshi(
 /**
  * Get the hash of the preimage for signing a BTC transaction input.
  *
+ * Deprecated, this call will be removed in a future release. Please
+ * use ``wally_tx_get_input_signature_hash``.
+ *
  * :param tx: The transaction to generate the signature hash from.
  * :param index: The input index of the input being signed for.
  * :param script: The (unprefixed) scriptCode for the input being signed.
@@ -797,6 +800,9 @@ WALLY_CORE_API int wally_tx_get_btc_signature_hash(
 
 /**
  * Get the hash of the preimage for signing a BTC taproot transaction input.
+ *
+ * Deprecated, this call will be removed in a future release. Please
+ * use ``wally_tx_get_input_signature_hash``.
  *
  * :param tx: The transaction to generate the signature hash from.
  * :param index: The input index of the input being signed for.
@@ -833,6 +839,9 @@ WALLY_CORE_API int wally_tx_get_btc_taproot_signature_hash(
 
 /**
  * Get the hash of the preimage for signing a BTC transaction input.
+ *
+ * Deprecated, this call will be removed in a future release. Please
+ * use ``wally_tx_get_input_signature_hash``.
  *
  * :param tx: The transaction to generate the signature hash from.
  * :param index: The input index of the input being signed for.
@@ -1361,6 +1370,9 @@ WALLY_CORE_API int wally_tx_confidential_value_to_satoshi(
 
 /**
  * Get the hash of the preimage for signing an Elements transaction input.
+ *
+ * Deprecated, this call will be removed in a future release. Please
+ * use ``wally_tx_get_input_signature_hash``.
  *
  * :param tx: The transaction to generate the signature hash from.
  * :param index: The input index of the input being signed for.

--- a/src/tx_io.c
+++ b/src/tx_io.c
@@ -962,9 +962,11 @@ int wally_tx_get_input_signature_hash(
         !flags || (flags & ~SIGTYPE_ALL) || !bytes_out || len != SHA256_LEN)
         return WALLY_EINVAL;
 
-#ifdef BUILD_ELEMENTS
     if ((ret = wally_tx_is_elements(tx, &is_elements)) != WALLY_OK)
         return ret;
+#ifndef BUILD_ELEMENTS
+    if (is_elements)
+        return WALLY_EINVAL;
 #endif
 
     switch (sighash) {
@@ -1017,5 +1019,5 @@ int wally_tx_get_input_signature_hash(
                                      genesis_blockhash, genesis_blockhash_len,
                                      sighash, cache, is_elements,
                                      bytes_out, len);
-    return WALLY_EINVAL;
+    return WALLY_EINVAL; /* Unknown sighash type */
 }


### PR DESCRIPTION
This completes moving signature hash generation to the new, caching interface. Although pre-segwit transactions do not benefit from caching, the new impl is cleaner and uses less stack. Additionally, it allows removing all signature hash generation code from the transaction serialization code, making it easier to reason about.