### PR TITLE
Mbed sha256

### DIFF
--- a/src/ccan/ccan/compiler/compiler.h
+++ b/src/ccan/ccan/compiler/compiler.h
@@ -228,4 +228,16 @@
 #define WARN_UNUSED_RESULT
 #endif
 #endif
+
+/* ALIGNED - ensure a structure/variable is aligned to a given number of bytes
+ *
+ */
+#ifndef ALIGNED
+#if (defined(__clang__) || defined(__GNUC__))
+#define ALIGNED(N) __attribute__((aligned(N)))
+#else
+#define ALIGNED(N)
+#endif
+#endif /* ALIGNED */
+
 #endif /* CCAN_COMPILER_H */

--- a/src/ccan/ccan/crypto/sha256/sha256.c
+++ b/src/ccan/ccan/crypto/sha256/sha256.c
@@ -59,6 +59,7 @@ inline void sha256_update(struct sha256_ctx *ctx, const void *p, size_t size)
 inline void sha256_done(struct sha256_ctx *ctx, struct sha256* res)
 {
 	mbedtls_sha256_finish(&ctx->c, res->u.u8);
+	mbedtls_sha256_free(&ctx->c);
 }
 void sha256_optimize(void)
 {

--- a/src/ccan/ccan/crypto/sha256/sha256_sse4.c
+++ b/src/ccan/ccan/crypto/sha256/sha256_sse4.c
@@ -9,9 +9,6 @@
 #include <stdlib.h>
 
 #if defined(__x86_64__) || defined(__amd64__)
-/* TODO: Support alignment in compiler.h */
-#define ALIGNED(N) __attribute__((aligned(N)))
-
 void TransformSSE4(uint32_t* s, const uint32_t* chunk, size_t blocks)
 {
     static const uint32_t K256[] ALIGNED(16) = {


### PR DESCRIPTION
Cleanups for the ccan sha code and a fix for tx_io hashing for non-default sha256 implementations (affecting taproot txs with more than 1 taproot input).
