### PR TITLE
descriptor: support elements confidential wallet policies

### DIFF
--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -50,34 +50,39 @@ static struct wally_map_item g_key_map_items[] = {
     { B("slip77_key"), B("b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04") }
 };
 
-static const struct wally_map g_key_map = {
-    g_key_map_items,
-    NUM_ELEMS(g_key_map_items),
-    NUM_ELEMS(g_key_map_items),
-    NULL
-};
-
 static struct wally_map_item g_policy_map_items[] = {
+    { B("@B"), B("b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04") },
     { B("@0"), B("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL") },
     { B("@1"), B("xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU") }
+};
+
+static struct wally_map_item g_elip150_map_items[] = {
+    { B("@B"), B("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL") },
+    { B("@0"), B("xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU") }
 };
 
 /* key-variable maps for policy testing.
  * The bip refers to these as "key information vectors".
  */
-static const struct wally_map g_policy_maps[3] = {
+static struct wally_map g_vars[] = {
     /* Standard convenience key map for more readable test cases */
-    g_key_map,
+    { g_key_map_items, NUM_ELEMS(g_key_map_items), NUM_ELEMS(g_key_map_items), NULL },
     /* Wallet policy key map with 1 element "@0" */
-    { g_policy_map_items, 1, 1, NULL },
+    { &g_policy_map_items[1], 1, 1, NULL },
     /* Wallet policy key map with 2 elements "@0", "@1"  */
-    { g_policy_map_items, 2, 2, NULL }
+    { &g_policy_map_items[1], 2, 2, NULL },
+    /* Confidential wallet policy key map with 2 elements "@B", "@0" */
+    { &g_policy_map_items[0], 2, 2, NULL },
+    /* Confidential wallet policy key map with 2 elements "@B", "@0" - @B is an elip150 key */
+    { &g_elip150_map_items[0], 2, 2, NULL }
 };
 
+/* Indices into g_vars */
 #define VARS_STD 0
 #define VARS_P_1 1
 #define VARS_P_2 2
 #define VARS_P_B 3
+#define VARS_PKB 4
 
 static const uint32_t g_miniscript_index_0 = 0;
 static const uint32_t g_miniscript_index_16 = 0x10;
@@ -1092,6 +1097,34 @@ static const struct descriptor_test {
         "a9146cc69bc5443e97b8a30918cb6297ba4efb3d6dc387",
         "45w36ywr", VARS_P_2
     },
+#ifdef BUILD_ELEMENTS
+    /* Elements/Confidential wallet policies */
+    {
+        "policy - single asterisk reconciliation (elements)",
+        "elpkh(mainnet_xpub/*)",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0,
+        "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
+        "j4aaf0ll", VARS_STD
+    }, {
+        "policy - single asterisk (elements)",
+        "elpkh(@0/*)", // Becomes "elpkh(mainnet_xpub/*)" i.e. the test case above this
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
+        "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
+        "j4aaf0ll", VARS_P_1
+    }, {
+        "ct policy - reconcile 'single asterisk (elements)'",
+        "ct(slip77(@B),elpkh(@0/*))", // Becomes "elpkh(mainnet_xpub/*)"
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
+        "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
+        "a9kmw73l", VARS_P_B
+    }, {
+        "ct policy - elip150 pkh",
+        "ct(@B,elpkh(@0/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
+        "76a91462efbe8dc3addddf826260b6be0fac3489b606e088ac",
+        "q5gxyjhu", VARS_PKB
+    },
+#endif
     /*
      * Misc error cases (code coverage)
      */
@@ -1676,6 +1709,43 @@ static const struct descriptor_test {
         "ct(0202fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90,elwpkh(key_4))",
         WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }
+    /* Elements/Confidential wallet policy error cases */
+    , {
+        "ct policy errchk - No substitutions",
+        "ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
+    }, {
+        "ct policy errchk - No blinding key substitution",
+        "ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elpkh(@0/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_B
+    }, {
+        "ct policy errchk - No blinding key in vars",
+        "ct(slip77(@B),elpkh(@0/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
+    }, {
+        "ct policy errchk - blinding key with child path",
+        "ct(slip77(@B/**),elpkh(@0/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_B
+    }, {
+        "ct policy errchk - key without child path",
+        "ct(slip77(@B),elpkh(@0))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_B
+    }, {
+        "ct policy errchk - elip150 blinding key with child path",
+        "ct(@B/**,elpkh(@0/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_PKB
+    }, {
+        "ct policy errchk - elip150 with no blinding key substitution",
+        "ct(@0/**,elpkh(@1/**))",
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL,
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_2
+    },
 #endif /* BUILD_ELEMENTS */
 };
 
@@ -2270,7 +2340,7 @@ static bool check_descriptor_to_script(const struct descriptor_test* test)
     uint32_t multi_index = 0;
     uint32_t child_num = test->child_num ? *test->child_num : 0, features;
     const bool is_policy = test->flags & WALLY_MINISCRIPT_POLICY_TEMPLATE;
-    const struct wally_map *keys = &g_policy_maps[test->policy_map_index];
+    const struct wally_map *keys = &g_vars[test->policy_map_index];
 
     /* Parse the descriptor. */
     expected_ret = test->script ? WALLY_OK : WALLY_EINVAL;
@@ -2416,8 +2486,8 @@ static bool check_descriptor_to_address(const struct address_test *test)
     size_t i;
     int ret, expected_ret = *test->addresses[0] ? WALLY_OK : WALLY_EINVAL;
 
-    ret = wally_descriptor_parse(test->descriptor, &g_key_map, test->network,
-                                 flags, &descriptor);
+    ret = wally_descriptor_parse(test->descriptor, &g_vars[VARS_STD],
+                                 test->network, flags, &descriptor);
 
     if (expected_ret == WALLY_OK || ret == expected_ret) {
         /* For failure cases, we may fail when generating instead of parsing,

--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -62,13 +62,22 @@ static struct wally_map_item g_policy_map_items[] = {
     { B("@1"), B("xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU") }
 };
 
-/* 1 and 2 element key variable maps for policy testing.
+/* key-variable maps for policy testing.
  * The bip refers to these as "key information vectors".
  */
-static const struct wally_map g_policy_maps[2] = {
+static const struct wally_map g_policy_maps[3] = {
+    /* Standard convenience key map for more readable test cases */
+    g_key_map,
+    /* Wallet policy key map with 1 element "@0" */
     { g_policy_map_items, 1, 1, NULL },
-    { g_policy_map_items, NUM_ELEMS(g_policy_map_items), NUM_ELEMS(g_policy_map_items), NULL }
+    /* Wallet policy key map with 2 elements "@0", "@1"  */
+    { g_policy_map_items, 2, 2, NULL }
 };
+
+#define VARS_STD 0
+#define VARS_P_1 1
+#define VARS_P_2 2
+#define VARS_P_B 3
 
 static const uint32_t g_miniscript_index_0 = 0;
 static const uint32_t g_miniscript_index_16 = 0x10;
@@ -108,6 +117,7 @@ static const struct descriptor_test {
     const uint32_t flags;
     const char *script;
     const char *checksum;
+    int policy_map_index;
 } g_descriptor_cases[] = {
     /*
      * Output descriptors
@@ -117,288 +127,288 @@ static const struct descriptor_test {
         "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#gn28ywm7",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
-        "gn28ywm7"
+        "gn28ywm7", VARS_STD
     },{
         "descriptor - p2pk uncompressed",
         "pk(uncompressed)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "410414fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267be5645686309c6e6736dbd93940707cc9143d3cf29f1b877ff340e2cb2d259cfac",
-        "xfwtewl7"
+        "xfwtewl7", VARS_STD
     },{
         "descriptor - p2pkh",
         "pkh(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac",
-        "8fhd9pwu"
+        "8fhd9pwu", VARS_STD
     },{
         "descriptor - p2pkh uncompressed",
         "pkh(uncompressed)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a914bc11f399122b0bda5e5432aba3f5206dbb7dc18388ac",
-        "svxeae4h"
+        "svxeae4h", VARS_STD
     },{
         "descriptor - p2wpkh",
         "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "00147dd65592d0ab2fe0d0257d571abf032cd9db93dc",
-        "8zl0zxma"
+        "8zl0zxma", VARS_STD
     },{
         "descriptor - p2wpkh (bip143 test vector)",
         "wpkh(025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         /* From script "76a9141d0f172a0ecb48aee1be1f2687d2963ae33f71a188ac" */
         "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1",
-        "pw3pfgx0"
+        "pw3pfgx0", VARS_STD
     },{
         "descriptor - p2sh-p2wpkh",
         "sh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914cc6ffbc0bf31af759451068f90ba7a0272b6b33287",
-        "qkrrc7je"
+        "qkrrc7je", VARS_STD
     },{
         "descriptor - p2sh-p2wpkh (bip143 test vector)",
         "sh(wpkh(03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         /* From script "76a91479091972186c449eb1ded22b78e40d009bdf008988ac" */
         "a9144733f37cf4db86fbc2efed2500b4f4e49f31202387",
-        "946zr4e5"
+        "946zr4e5", VARS_STD
     },{
         "descriptor - combo(variant 0, p2pk)",
         "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
-        "lq9sf04s"
+        "lq9sf04s", VARS_STD
     },{
         "descriptor - combo(variant 1, p2pkh)",
         "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
         WALLY_NETWORK_NONE, 0, 0, 1, NULL, 0,
         "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
-        "lq9sf04s"
+        "lq9sf04s", VARS_STD
     },{
         "descriptor - combo(variant 2, p2wpkh)",
         "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
         WALLY_NETWORK_NONE, 0, 0, 2, NULL, 0,
         "0014751e76e8199196d454941c45d1b3a323f1433bd6",
-        "lq9sf04s"
+        "lq9sf04s", VARS_STD
     },{
         "descriptor - combo(variant 3, p2sh-p2wpkh)",
         "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
         WALLY_NETWORK_NONE, 0, 0, 3, NULL, 0,
         "a914bcfeb728b584253d5f3f70bcb780e9ef218a68f487",
-        "lq9sf04s"
+        "lq9sf04s", VARS_STD
     },{
         "descriptor - combo(variant 0, p2pk uncompressed)",
         "combo(04a238b0cbea14c9b3f59d0a586a82985f69af3da50579ed5971eefa41e6758ee7f1d77e4d673c6e7aac39759bb762d22259e27bf93572e9d5e363d5a64b6c062b)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "4104a238b0cbea14c9b3f59d0a586a82985f69af3da50579ed5971eefa41e6758ee7f1d77e4d673c6e7aac39759bb762d22259e27bf93572e9d5e363d5a64b6c062bac",
-        "r3wj6k68"
+        "r3wj6k68", VARS_STD
     },{
         "descriptor - combo(variant 1, p2pkh uncompressed)",
         "combo(04a238b0cbea14c9b3f59d0a586a82985f69af3da50579ed5971eefa41e6758ee7f1d77e4d673c6e7aac39759bb762d22259e27bf93572e9d5e363d5a64b6c062b)",
         WALLY_NETWORK_NONE, 0, 0, 1, NULL, 0,
         "76a91448cb866ee3edb295e4cfeb3da65b4003ab9fa6a288ac",
-        "r3wj6k68"
+        "r3wj6k68", VARS_STD
     },{
         "descriptor - combo(variant 2, p2wpkh uncompressed, invalid)",
         "combo(04a238b0cbea14c9b3f59d0a586a82985f69af3da50579ed5971eefa41e6758ee7f1d77e4d673c6e7aac39759bb762d22259e27bf93572e9d5e363d5a64b6c062b)",
         WALLY_NETWORK_NONE, 0, 0, 2, NULL, 0,
         NULL,
-        ""
+        "", VARS_STD
     },{
         "descriptor - combo(variant 3, p2sh-p2wpkh uncompressed, invalid)",
         "combo(04a238b0cbea14c9b3f59d0a586a82985f69af3da50579ed5971eefa41e6758ee7f1d77e4d673c6e7aac39759bb762d22259e27bf93572e9d5e363d5a64b6c062b)",
         WALLY_NETWORK_NONE, 0, 0, 3, NULL, 0,
         NULL,
-        ""
+        "", VARS_STD
     },{
         "descriptor - p2sh-p2wsh",
         "sh(wsh(pkh(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a91455e8d5e8ee4f3604aba23c71c2684fa0a56a3a1287",
-        "2wtr0ej5"
+        "2wtr0ej5", VARS_STD
     },{
         "descriptor - multisig",
         "multi(1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "5121022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe421025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc52ae",
-        "hzhjw406"
+        "hzhjw406", VARS_STD
     },{
         "descriptor - p2sh-multi",
         "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914a6a8b030a38762f4c1f5cbe387b61a3c5da5cd2687",
-        "y9zthqta"
+        "y9zthqta", VARS_STD
     },{
         "descriptor - p2sh-sortedmulti 1",
         "sh(sortedmulti(2,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914a6a8b030a38762f4c1f5cbe387b61a3c5da5cd2687",
-        "qwx6n9lh"
+        "qwx6n9lh", VARS_STD
     },{
         "descriptor - p2sh-sortedmulti 2",
         "sh(sortedmulti(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914a6a8b030a38762f4c1f5cbe387b61a3c5da5cd2687",
-        "fjpjdnvk" /* Note different checksum from p2sh-sortedmulti 1 */
+        "fjpjdnvk", VARS_STD /* Note different checksum from p2sh-sortedmulti 1 */
     },{
         "descriptor - p2wsh-multi",
         "wsh(multi(2,03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb,03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "0020773d709598b76c4e3b575c08aad40658963f9322affc0f8c28d1d9a68d0c944a",
-        "en3tu306"
+        "en3tu306", VARS_STD
     },{
         "descriptor - p2wsh-multi (from bitcoind's `createmultisig`)",
         "wsh(multi(2,03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd,03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         /* From script "522103789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd2103dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a6162652ae" */
         "00207ca68449d39a95da91c6c283871f587b74b45c1645a37f8c8337fd3d9ac4fee6",
-        "5wacx8g6"
+        "5wacx8g6", VARS_STD
     },{
         "descriptor - p2sh-p2wsh-multi",
         "sh(wsh(multi(1,03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8,03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914aec509e284f909f769bb7dda299a717c87cc97ac87",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     },{
         "descriptor - p2sh-p2wsh-multi (from bitcoind's `createmultisig`)",
         "sh(wsh(multi(2,03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd,03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         /* From script "522103789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd2103dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a6162652ae" */
         "a91411aca2b63fbee2cdda856217a8863135b070978b87",
-        "du4tngj2"
+        "du4tngj2", VARS_STD
     },{
         "descriptor - p2sh multisig 15",
         /*          1     2     3     4     5     6     7     8     9     10    11    12    13    14    15 */
         "sh(multi(1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914276b4ebc33265436a9c9b46ca23d6781aef98fe087",
-        "pckwejvm"
+        "pckwejvm", VARS_STD
     },{
         "descriptor - p2pk-xpub",
         "pk(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "210339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2ac",
-        "axav5m0j"
+        "axav5m0j", VARS_STD
     },{
         "descriptor - p2pkh-xpub-derive single child",
         "pkh(xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a914bef5a2f9a56a94aab12459f72ad9cf8cf19c7bbe88ac",
-        "kd8wch8l"
+        "kd8wch8l", VARS_STD
     },{
         "descriptor - p2pkh-xpub-derive",
         "pkh(xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw/1/2)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a914f833c08f02389c451ae35ec797fccf7f396616bf88ac",
-        "kczqajcv"
+        "kczqajcv", VARS_STD
     },{
         "descriptor - p2pkh-empty-path",
         "pkh([d34db33f/44'/0'/0']mainnet_xpub/)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91431a507b815593dfc51ffc7245ae7e5aee304246e88ac",
-        "ee44hjhg"
+        "ee44hjhg", VARS_STD
     },{
         "descriptor - p2pkh-empty-path h-hardened",
         "pkh([d34db33f/44h/0h/0h]mainnet_xpub/)#ltv22yxk",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91431a507b815593dfc51ffc7245ae7e5aee304246e88ac",
-        "ltv22yxk" /* Note different checksum despite being the same expression as above */
+        "ltv22yxk", VARS_STD /* Note different checksum despite being the same expression as above */
     },{
         "descriptor - p2pkh-parent-derive",
         "pkh([d34db33f/44'/0'/0']mainnet_xpub/1/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, &g_miniscript_index_16, 0,
         "76a914d234825a563de8b4fd31d2b30f60b1e60fe57ee788ac",
-        "ml40v0wf"
+        "ml40v0wf", VARS_STD
     },{
         "descriptor - ranged and non-ranged keys (1)",
         "multi(2,mainnet_xpub,mainnet_xpub/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, &g_miniscript_index_16, 0,
         "522102d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f02102fb7d86f93bb0f5958171e05473bf36d99a850596b0a8dbe086a0101d4946083a52ae",
-        "e0pf8z74"
+        "e0pf8z74", VARS_STD
     },{
         "descriptor - p2wsh-multi-xpub",
         "wsh(multi(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,key_4/0/0/*))",
         WALLY_NETWORK_NONE, 0, 0, 0, &g_miniscript_index_16, 0,
         "00204616bb4e66d0b540b480c5b26c619385c4c2b83ed79f4f3eab09b01745443a55",
-        "t2zpj2eu"
+        "t2zpj2eu", VARS_STD
     },{
         "descriptor - p2wsh-sortedmulti-xpub",
         "wsh(sortedmulti(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,key_4/0/0/*))",
         WALLY_NETWORK_NONE, 0, 0, 0, &g_miniscript_index_16, 0,
         "002002aeee9c3773dfecfe6215f2eea2908776b1232513a700e1ee516b634883ecb0",
-        "v66cvalc"
+        "v66cvalc", VARS_STD
     },{
         "descriptor - addr-btc-legacy-testnet",
         "addr(moUfpGiXWcFd5ueRn3988VDqRSkB5NrEmW)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91457526b1a1534d4bde788253281649fc2e91dc70b88ac",
-        "9amhxcar"
+        "9amhxcar", VARS_STD
     },{
         "descriptor - addr-btc-segwit-mainnet",
         "addr(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-        "8kzm8txf"
+        "8kzm8txf", VARS_STD
     },{
         "descriptor - empty raw",
         "raw()",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "",
-        "58lrscpx"
+        "58lrscpx", VARS_STD
     }, {
         "descriptor - raw-checksum",
         "raw(6a4c4f54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e)#zf2avljj",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "6a4c4f54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e",
-        "zf2avljj"
+        "zf2avljj", VARS_STD
     },{
         "descriptor - p2pkh-xpriv",
         "pkh(mainnet_xpriv/1h/2)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a914b28d12ab72a51b10114b17ce76b536265194e1fb88ac",
-        "wghlxksl"
+        "wghlxksl", VARS_STD
     },{
         "descriptor - p2pkh-xpriv hardened last child",
         "pkh(mainnet_xpriv/1h/2h)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a9148ab3d0acbde6766fb0a24e0e4286168c2a24a7a088ac",
-        "cj20v7ag"
+        "cj20v7ag", VARS_STD
     },{
         "descriptor - p2pkh-privkey-wif mainnet",
         "pkh(L1AAHuEC7XuDM7pJ7yHLEqYK1QspMo8n1kgxyZVdgvEpVC1rkUrM)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91492ed3283cfb01caec1163aefba29caf1182f478e88ac",
-        "qm00tjwh"
+        "qm00tjwh", VARS_STD
     },{
         "descriptor - p2pkh-privkey-wif testnet uncompressed",
         "pkh(936Xapr4wpeuiKToGeXtEcsVJAfE6ze8KUEb2UQu72rzBQsMZdX)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a91477b6f27ac523d8b9aa8abcfc94fd536493202ae088ac",
-        "9gv5p2gj"
+        "9gv5p2gj", VARS_STD
     },{
         "descriptor - rawtr - x-only",
         "rawtr(x_only)",
         WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
         "5120b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e",
-        "nsnjmrf4"
+        "nsnjmrf4", VARS_STD
     },{
         "descriptor - rawtr - non-x-only returns the same script as x-only",
         "rawtr(non_x_only)",
         WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
         "5120b71aa79cab0ae2d83b82d44cbdc23f5dcca3797e8ba622c4e45a8f7dce28ba0e",
-        "ha989syu"
+        "ha989syu", VARS_STD
     },{
         "descriptor - tr - x-only",
         "tr(x_only)",
         WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
         "51205fb8e39dbbdc7c831af59e44a9b2997f9daaf72c3e965b30982f3c731539e1db",
-        "axny68jy"
+        "axny68jy", VARS_STD
     },{
         "descriptor - tr - non-x-only returns the same script as x-only",
         "tr(non_x_only)",
         WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0,
         "51205fb8e39dbbdc7c831af59e44a9b2997f9daaf72c3e965b30982f3c731539e1db",
-        "tp2ky708"
+        "tp2ky708", VARS_STD
     },
 #ifdef BUILD_ELEMENTS
     /* Elements/Confidential descriptors */
@@ -407,19 +417,19 @@ static const struct descriptor_test {
         "tr([59d1f3b0/86h/1h/0h]jade_ss_tr_xpriv/0/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_AS_ELEMENTS,
         "5120900d1d75269396d4220c4529527dbcb746a6093c7209cea2d76a87c8ab9447fc",
-        "3d4maj53"
+        "3d4maj53", VARS_STD
     }, {
         "descriptor - Elements eltr()",
         "eltr([59d1f3b0/86h/1h/0h]jade_ss_tr_xpriv/0/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "5120900d1d75269396d4220c4529527dbcb746a6093c7209cea2d76a87c8ab9447fc",
-        "nldl65wt"
+        "nldl65wt", VARS_STD
     }, {
         "descriptor - slip77 (ELIP150 Valid Descriptor 5)",
         "ct(slip77(slip77_key),elpkh(key_4))#hw2glz99",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "76a9145a61ff8eb7aaca3010db97ebda76121610b7809688ac",
-        "hw2glz99"
+        "hw2glz99", VARS_STD
     },
 #endif
     {
@@ -427,43 +437,43 @@ static const struct descriptor_test {
         "wsh(c:pk_k(key_1))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "0020fa5bf4aae3ee617c6cce1976f6d7d285c359613ffeed481f1067f62bc0f54852",
-        "9u0h8j4t"
+        "9u0h8j4t", VARS_STD
     },{
         "descriptor - One of two keys (equally likely)",
         "wsh(or_b(c:pk_k(key_1),sc:pk_k(key_2)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "002018a9df986ba10bcd8f503f495cab5fd00c9fb23c05143e65dbba49ef4d8a825f",
-        "hyh0kcqw"
+        "hyh0kcqw", VARS_STD
     },{
         "descriptor - A user and a 2FA service need to sign off, but after 90 days the user alone is enough",
         "wsh(and_v(vc:pk_k(key_user),or_d(c:pk_k(key_service),older(12960))))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "00201264946c666958d9522f63dcdcfc85941bdd5b9308b1e6c68696857506f6cced",
-        "nwlxsraz"
+        "nwlxsraz", VARS_STD
     },{
         "descriptor - The BOLT #3 to_local policy",
         "wsh(andor(c:pk_k(key_local),older(1008),c:pk_k(key_revocation)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "0020052cf1e9c90e9a2883d890467a6a01837e21b3b755a743c9d96a2b6f8285d7c0",
-        "hthd6qg9"
+        "hthd6qg9", VARS_STD
     },{
         "descriptor - The BOLT #3 offered HTLC policy",
         "wsh(t:or_c(c:pk_k(key_revocation),and_v(vc:pk_k(key_remote),or_c(c:pk_k(key_local),v:hash160(H)))))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "0020f9259363db0facc7b97ab2c0294c4f21a0cd56b01bb54ecaaa5899012aae1bc2",
-        "0hmjukva"
+        "0hmjukva", VARS_STD
     },{
         "descriptor - The BOLT #3 received HTLC policy",
         "wsh(andor(c:pk_k(key_remote),or_i(and_v(vc:pk_h(key_local),hash160(H)),older(1008)),c:pk_k(key_revocation)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "002087515e0059c345eaa5cccbaa9cd16ad1266e7a69e350db82d8e1f33c86285303",
-        "8re62ejc"
+        "8re62ejc", VARS_STD
     },{
         "descriptor - derive key index 0",
         "wsh(multi(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,key_4/0/0/*))",
         WALLY_NETWORK_NONE, 0, 0, 0, &g_miniscript_index_0, 0,
         "002064969d8cdca2aa0bb72cfe88427612878db98a5f07f9a7ec6ec87b85e9f9208b",
-        "t2zpj2eu"
+        "t2zpj2eu", VARS_STD
     },
     /* https://github.com/rust-bitcoin/rust-miniscript/blob/master/src/descriptor/checksum.rs */
     {
@@ -471,14 +481,14 @@ static const struct descriptor_test {
         "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "0014e2d19350c9d8722e2994c81791f4a0ba115bc479",
-        "tqz0nc62"
+        "tqz0nc62", VARS_STD
     }, {
         /* https://github.com/bitcoin/bitcoin/blob/7ae86b3c6845873ca96650fc69beb4ae5285c801/src/test/descriptor_tests.cpp#L352-L354 */
         "descriptor - core checksum",
         "sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a91445a9a622a8b0a1269944be477640eedc447bbd8487",
-        "ggrsrxfy"
+        "ggrsrxfy", VARS_STD
     },
     /*
      * Depth/index test cases (for generating sub-scripts)
@@ -488,43 +498,43 @@ static const struct descriptor_test {
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "a914aec509e284f909f769bb7dda299a717c87cc97ac87",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (p2wsh)",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 1, 0, 0, NULL, 0,
         "0020ef8110fa7ddefb3e2d02b2c1b1480389b4bc93f606281570cfc20dba18066aee",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (multi)",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 2, 0, 0, NULL, 0,
         "512103f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa82103499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e42102d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e53ae",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (multi[0])",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 3, 0, 0, NULL, 0,
         "51",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (multi[1])",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 3, 1, 0, NULL, 0,
         "03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (multi[2])",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 3, 2, 0, NULL, 0,
         "03499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     }, {
         "descriptor depth - p2sh-p2wsh-multi (multi[3])",
         DEPTH_TEST_DESCRIPTOR,
         WALLY_NETWORK_NONE, 3, 3, 0, NULL, 0,
         "02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e",
-        "ks05yr6p"
+        "ks05yr6p", VARS_STD
     },
     /*
      * Miniscript: https://bitcoin.sipa.be/miniscript/
@@ -534,7 +544,7 @@ static const struct descriptor_test {
         "thresh(3,pk(key_1),s:pk(key_2),s:pk(key_3),sln:older(12960))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac7c2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac937c2103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac937c63006702a032b29268935387",
-        "2sw64huw"
+        "2sw64huw", VARS_STD
     },
     /*
      * Miniscript: Randomly generated test set that covers the majority of type and node type combinations
@@ -544,235 +554,235 @@ static const struct descriptor_test {
         "pk_k(key_1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048",
-        "jyazm5lc"
+        "jyazm5lc", VARS_STD
     },{
         "miniscript - random 1",
         "lltvln:after(1231488000)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6300676300676300670400046749b1926869516868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 2",
         "uuj:and_v(v:multi(2,03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a,025601570cb47f238d2b0286db4a990fa0f3ba28d1a319f5e7cf55c2a2444da7cc),after(1231488000))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6363829263522103d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a21025601570cb47f238d2b0286db4a990fa0f3ba28d1a319f5e7cf55c2a2444da7cc52af0400046749b168670068670068",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 3",
         "or_b(un:multi(2,03daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729,024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c97),al:older(16))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "63522103daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee872921024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c9752ae926700686b63006760b2686c9b",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 4",
         "j:and_v(vdv:after(1567547623),older(2016))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "829263766304e7e06e5db169686902e007b268",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 5",
         "t:and_v(vu:hash256(131772552c01444cd81360818376a040b7c3b2b7b0a53550ee3edde216cec61b),v:sha256(ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6382012088aa20131772552c01444cd81360818376a040b7c3b2b7b0a53550ee3edde216cec61b876700686982012088a820ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc58851",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 6",
         "t:andor(multi(3,02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556,02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13),v:older(4194305),v:sha256(9267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed2))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "532102d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e2103fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a14602975562102e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd1353ae6482012088a8209267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed2886703010040b2696851",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 7",
         "or_d(multi(1,02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9),or_b(multi(3,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,032fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f,03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a),su:after(500000)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "512102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f951ae73645321022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a0121032fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f2103d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a53ae7c630320a107b16700689b68",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 8",
         "or_d(sha256(38df1c1f64a24a77b23393bca50dff872e31edc4f3b5aa3b90ad0b82f4f089b6),and_n(un:after(499999999),older(4194305)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088a82038df1c1f64a24a77b23393bca50dff872e31edc4f3b5aa3b90ad0b82f4f089b68773646304ff64cd1db19267006864006703010040b26868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 9",
         "and_v(or_i(v:multi(2,02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb),v:multi(2,03e60fce93b59e9ec53011aabc21c23e97b2a31369b87a5ae9c44ee89e2a6dec0a,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)),sha256(d1ec675902ef1633427ca360b290b0b3045a0d9058ddb5e648b4c3c3224c5c68))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "63522102c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee52103774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb52af67522103e60fce93b59e9ec53011aabc21c23e97b2a31369b87a5ae9c44ee89e2a6dec0a21025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc52af6882012088a820d1ec675902ef1633427ca360b290b0b3045a0d9058ddb5e648b4c3c3224c5c6887",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 10",
         "j:and_b(multi(2,0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c97),s:or_i(older(1),older(4252898)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82926352210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179821024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c9752ae7c6351b26703e2e440b2689a68",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 11",
         "and_b(older(16),s:or_d(sha256(e38990d0c7fc009880a9c07c23842e886c6bbdc964ce6bdd5817ad357335ee6f),n:after(1567547623)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "60b27c82012088a820e38990d0c7fc009880a9c07c23842e886c6bbdc964ce6bdd5817ad357335ee6f87736404e7e06e5db192689a",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 12",
         "j:and_v(v:hash160(20195b5a3d650c17f0f29f91c33f8f6335193d07),or_d(sha256(96de8fc8c256fa1e1556d41af431cace7dca68707c78dd88c3acab8b17164c47),older(16)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82926382012088a91420195b5a3d650c17f0f29f91c33f8f6335193d078882012088a82096de8fc8c256fa1e1556d41af431cace7dca68707c78dd88c3acab8b17164c4787736460b26868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 13",
         "and_b(hash256(32ba476771d01e37807990ead8719f08af494723de1d228f2c2c07cc0aa40bac),a:and_b(hash256(131772552c01444cd81360818376a040b7c3b2b7b0a53550ee3edde216cec61b),a:older(1)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088aa2032ba476771d01e37807990ead8719f08af494723de1d228f2c2c07cc0aa40bac876b82012088aa20131772552c01444cd81360818376a040b7c3b2b7b0a53550ee3edde216cec61b876b51b26c9a6c9a",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 14",
         "thresh(2,multi(2,03a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7,036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a00),a:multi(1,036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a00),ac:pk_k(022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "522103a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c721036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a0052ae6b5121036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a0051ae6c936b21022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01ac6c935287",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 15",
         "and_n(sha256(d1ec675902ef1633427ca360b290b0b3045a0d9058ddb5e648b4c3c3224c5c68),t:or_i(v:older(4252898),v:older(144)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088a820d1ec675902ef1633427ca360b290b0b3045a0d9058ddb5e648b4c3c3224c5c68876400676303e2e440b26967029000b269685168",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 16",
         "or_d(d:and_v(v:older(4252898),v:older(4252898)),sha256(38df1c1f64a24a77b23393bca50dff872e31edc4f3b5aa3b90ad0b82f4f089b6))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "766303e2e440b26903e2e440b26968736482012088a82038df1c1f64a24a77b23393bca50dff872e31edc4f3b5aa3b90ad0b82f4f089b68768",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 17",
         "c:and_v(or_c(sha256(9267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed2),v:multi(1,02c44d12c7065d812e8acf28d7cbb19f9011ecd9e9fdf281b0e6a3b5e87d22e7db)),pk_k(03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088a8209267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed28764512102c44d12c7065d812e8acf28d7cbb19f9011ecd9e9fdf281b0e6a3b5e87d22e7db51af682103acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbeac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 18",
         "c:and_v(or_c(multi(2,036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a00,02352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d5),v:ripemd160(1b0f3c404d12075c68c938f9f60ebea4f74941a0)),pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "5221036d2b085e9e382ed10b69fc311a03f8641ccfff21574de0927513a49d9a688a002102352bbf4a4cdd12564f93fa332ce333301d9ad40271f8107181340aef25be59d552ae6482012088a6141b0f3c404d12075c68c938f9f60ebea4f74941a088682103fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 19",
         "and_v(andor(hash256(8a35d9ca92a48eaade6f53a64985e9e2afeb74dcf8acb4c3721e0dc7e4294b25),v:hash256(939894f70e6c3a25da75da0cc2071b4076d9b006563cf635986ada2e93c0d735),v:older(50000)),after(499999999))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088aa208a35d9ca92a48eaade6f53a64985e9e2afeb74dcf8acb4c3721e0dc7e4294b2587640350c300b2696782012088aa20939894f70e6c3a25da75da0cc2071b4076d9b006563cf635986ada2e93c0d735886804ff64cd1db1",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 20",
         "andor(hash256(5f8d30e655a7ba0d7596bb3ddfb1d2d20390d23b1845000e1e118b3be1b3f040),j:and_v(v:hash160(3a2bff0da9d96868e66abc4427bea4691cf61ccd),older(4194305)),ripemd160(44d90e2d3714c8663b632fcf0f9d5f22192cc4c8))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088aa205f8d30e655a7ba0d7596bb3ddfb1d2d20390d23b1845000e1e118b3be1b3f040876482012088a61444d90e2d3714c8663b632fcf0f9d5f22192cc4c8876782926382012088a9143a2bff0da9d96868e66abc4427bea4691cf61ccd8803010040b26868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 21",
         "or_i(c:and_v(v:after(500000),pk_k(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)),sha256(d9147961436944f43cd99d28b2bbddbf452ef872b30c8279e255e7daafc7f946))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "630320a107b1692102c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5ac6782012088a820d9147961436944f43cd99d28b2bbddbf452ef872b30c8279e255e7daafc7f9468768",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 22",
         "thresh(2,c:pk_h(025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc),s:sha256(e38990d0c7fc009880a9c07c23842e886c6bbdc964ce6bdd5817ad357335ee6f),a:hash160(dd69735817e0e3f6f826a9238dc2e291184f0131))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "76a9145dedfbf9ea599dd4e3ca6a80b333c472fd0b3f6988ac7c82012088a820e38990d0c7fc009880a9c07c23842e886c6bbdc964ce6bdd5817ad357335ee6f87936b82012088a914dd69735817e0e3f6f826a9238dc2e291184f0131876c935287",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 23",
         "and_n(sha256(9267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed2),uc:and_v(v:older(144),pk_k(03fe72c435413d33d48ac09c9161ba8b09683215439d62b7940502bda8b202e6ce)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088a8209267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed28764006763029000b2692103fe72c435413d33d48ac09c9161ba8b09683215439d62b7940502bda8b202e6ceac67006868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 24",
         "and_n(c:pk_k(03daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729),and_b(l:older(4252898),a:older(16)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729ac64006763006703e2e440b2686b60b26c9a68",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 25",
         "c:or_i(and_v(v:older(16),pk_h(02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e)),pk_h(026a245bf6dc698504c89a20cfded60853152b695336c28063b61c65cbd269e6b4))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6360b26976a9149fc5dbe5efdce10374a4dd4053c93af540211718886776a9142fbd32c8dd59ee7c17e66cb6ebea7e9846c3040f8868ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 26",
         "or_d(c:pk_h(02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13),andor(c:pk_k(024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c97),older(2016),after(1567547623)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "76a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac736421024ce119c96e2fa357200b559b2f7dd5a5f02d5290aff74b03f3e471b273211c97ac6404e7e06e5db16702e007b26868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 27",
         "c:andor(ripemd160(6ad07d21fd5dfc646f0b30577045ce201616b9ba),pk_h(02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e),and_v(v:hash256(8a35d9ca92a48eaade6f53a64985e9e2afeb74dcf8acb4c3721e0dc7e4294b25),pk_h(03d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "82012088a6146ad07d21fd5dfc646f0b30577045ce201616b9ba876482012088aa208a35d9ca92a48eaade6f53a64985e9e2afeb74dcf8acb4c3721e0dc7e4294b258876a914dd100be7d9aea5721158ebde6d6a1fd8fff93bb1886776a9149fc5dbe5efdce10374a4dd4053c93af5402117188868ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 28",
         "c:andor(u:ripemd160(6ad07d21fd5dfc646f0b30577045ce201616b9ba),pk_h(03daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729),or_i(pk_h(022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01),pk_h(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6382012088a6146ad07d21fd5dfc646f0b30577045ce201616b9ba87670068646376a9149652d86bedf43ad264362e6e6eba6eb764508127886776a914751e76e8199196d454941c45d1b3a323f1433bd688686776a91420d637c1a6404d2227f3561fdbaff5a680dba6488868ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 29",
         "c:or_i(andor(c:pk_h(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),pk_h(022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01),pk_h(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)),pk_k(02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6376a914fcd35ddacad9f2d5be5e464639441c6065e6955d88ac6476a91406afd46bcdfd22ef94ac122aa11f241244a37ecc886776a9149652d86bedf43ad264362e6e6eba6eb7645081278868672102d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e68ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 30",
         "thresh(1,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),altv:after(1000000000),altv:after(100))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac6b6300670400ca9a3bb16951686c936b6300670164b16951686c935187",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 31",
         "thresh(2,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),ac:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),altv:after(1000000000),altv:after(100))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac6b2103fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556ac6c936b6300670400ca9a3bb16951686c936b6300670164b16951686c935287",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 32",
         "thresh(2,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),altv:after(100))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac6b6300670164b16951686c935287",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 33",
         "thresh(1,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac7c2103fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556ac935187",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 34",
         "after(100)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "0164b1",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 35",
         "after(1000000000)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "0400ca9a3bb1",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 36",
         "or_b(l:after(100),al:after(1000000000))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6300670164b1686b6300670400ca9a3bb1686c9b",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 37",
         "and_b(after(100),a:after(1000000000))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "0164b16b0400ca9a3bb16c9a",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - random 38",
         "thresh(2,ltv:after(1000000000),altv:after(100),a:pk(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6300670400ca9a3bb16951686b6300670164b16951686c936b2103d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac6c935287",
-        ""
+        "", VARS_STD
     },
     /*
      * Miniscript: Error cases
@@ -782,49 +792,49 @@ static const struct descriptor_test {
         "lltvlnlltvln:after(1231488000)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Number too small to parse",
         "older(-9223372036854775808)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Number too large to parse",
         "older(9223372036854775807)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Rust-miniscript issue 63",
         "nl:0",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Rust-miniscript context test",
         "or_i(pk(uncompressed),pk(uncompressed))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Threshold greater than the number of policies",
         "thresh(3,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Threshold of 0 is not allowed",
         "thresh(0,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     }, {
         "miniscript - Unknown wrapper type",
         "z:1",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         NULL,
-        ""
+        "", VARS_STD
     },
     /*
      * Miniscript: BOLT examples
@@ -834,73 +844,73 @@ static const struct descriptor_test {
         "c:pk_k(key_1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - A single key + CHECKSIG (2)",
         "pk(key_1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - One of two keys (equally likely)",
         "or_b(c:pk_k(key_1),sc:pk_k(key_2))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac7c2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac9b",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - One of two keys (equally likely) (2)",
         "or_b(pk(key_1),s:pk(key_2))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac7c2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac9b",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - A user and a 2FA service need to sign off, but after 90 days the user alone is enough",
         "and_v(vc:pk_k(key_user),or_d(c:pk_k(key_service),older(12960)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ad2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac736402a032b268",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - A user and a 2FA service need to sign off, but after 90 days the user alone is enough (2)",
         "and_v(v:pk(key_user),or_d(pk(key_service),older(12960)))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ad2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac736402a032b268",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 to_local policy",
         "andor(c:pk_k(key_local),older(1008),c:pk_k(key_revocation))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac642103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac6702f003b268",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 to_local policy (2)",
         "andor(pk(key_local),older(1008),pk(key_revocation))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac642103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac6702f003b268",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 offered HTLC policy",
         "t:or_c(c:pk_k(key_revocation),and_v(vc:pk_k(key_remote),or_c(c:pk_k(key_local),v:hash160(H))))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac642103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ad21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac6482012088a914d0721279e70d39fb4aa409b52839a0056454e3b588686851",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 offered HTLC policy (2)",
         "t:or_c(pk(key_revocation),and_v(v:pk(key_remote),or_c(pk(key_local),v:hash160(H))))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac642103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ad21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac6482012088a914d0721279e70d39fb4aa409b52839a0056454e3b588686851",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 received HTLC policy",
         "andor(c:pk_k(key_remote),or_i(and_v(vc:pk_h(key_local),hash160(H)),older(1008)),c:pk_k(key_revocation))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac642103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac676376a914d0721279e70d39fb4aa409b52839a0056454e3b588ad82012088a914d0721279e70d39fb4aa409b52839a0056454e3b5876702f003b26868",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - The BOLT #3 received HTLC policy (2)",
         "andor(pk(key_remote),or_i(and_v(v:pkh(key_local),hash160(H)),older(1008)),pk(key_revocation))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac642103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac676376a914d0721279e70d39fb4aa409b52839a0056454e3b588ad82012088a914d0721279e70d39fb4aa409b52839a0056454e3b5876702f003b26868",
-        ""
+        "", VARS_STD
     },
     /*
      * Wrappers ('a' case and positioning is handled below)
@@ -912,7 +922,7 @@ static const struct descriptor_test {
          */
         "miniscript - 's' wrapper",
         "s:1",
-        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, ""
+        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, "", VARS_STD
     },
     {
         /* NOTE: Core generates "1 OP_CHECKSIG", but "1" is not type K and so
@@ -921,7 +931,7 @@ static const struct descriptor_test {
          */
         "miniscript - 'c' wrapper",
         "c:1",
-        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, ""
+        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, "", VARS_STD
     },
     {
         /* NOTE: Core generates "1 1", but "1" is not type V and so
@@ -930,7 +940,7 @@ static const struct descriptor_test {
          */
         "miniscript - 't' wrapper",
         "t:1",
-        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, ""
+        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, "", VARS_STD
     },
     {
         /* NOTE: Core generates "OP_DUP OP_IF 1 OP_ENDIF", but "1" is not type
@@ -939,14 +949,14 @@ static const struct descriptor_test {
          */
         "miniscript - 'd' wrapper",
         "d:1",
-        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, ""
+        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, "", VARS_STD
     },
     {
         "miniscript - 'v' wrapper",
         "v:1",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "5169", /* 1 OP_VERIFY */
-        "zd904w4w"
+        "zd904w4w", VARS_STD
     },
     {
         /* NOTE: Core generates "OP_SIZE OP_0NOTEQUAL OP_IF 1 OP_ENDIF", but
@@ -956,14 +966,14 @@ static const struct descriptor_test {
          */
         "miniscript - 'j' wrapper",
         "j:1",
-        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, ""
+        WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY, NULL, "", VARS_STD
     },
     {
         "miniscript - 'n' wrapper",
         "n:1",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "5192", /* 1 OP_0NOTEQUAL */
-        "d959hk4q"
+        "d959hk4q", VARS_STD
     },
     /*
      * Miniscript taproot cases
@@ -973,19 +983,19 @@ static const struct descriptor_test {
         "c:pk_k(daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY | WALLY_MINISCRIPT_TAPSCRIPT,
         "20daed4f2be3a8bf278e70132fb0beb7522f570e144bf615c07e996d443dee8729ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - taproot bip32 key",
         "c:pk_k([bd16bee5/0]key_4/0/0/1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY | WALLY_MINISCRIPT_TAPSCRIPT,
         "208c6f5956c3cc7251d483fc683fa06b22d4e2ddc7496a2590acee36c4a313f816ac",
-        ""
+        "", VARS_STD
     }, {
         "miniscript - taproot WIF",
         "c:pk_k(L1AAHuEC7XuDM7pJ7yHLEqYK1QspMo8n1kgxyZVdgvEpVC1rkUrM)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY | WALLY_MINISCRIPT_TAPSCRIPT,
         "20ff7e7b1d3c4ba385cb1f2e6423bf30c96fb5007e7917b09ec1b6c965ef644d13ac",
-        ""
+        "", VARS_STD
     },
     /*
      * Ledger 'a' wrapper vulnerability:
@@ -996,21 +1006,21 @@ static const struct descriptor_test {
         "a:1",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6b516c", /* OP_TOALTSTACK 1 OP_FROMALTSTACK */
-        "7yjru3ju"
+        "7yjru3ju", VARS_STD
     },
     {
         "miniscript - Ledger 'a' wrapper bug (interior arg of a built-in)",
         "and_b(a:1,pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798))",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "6b516c210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac9a",
-        "c27u392r"
+        "c27u392r", VARS_STD
     },
     {
         "miniscript - Ledger 'a' wrapper bug (final arg of built-in)",
         "and_b(pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798),a:1)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, WALLY_MINISCRIPT_ONLY,
         "210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac6b516c9a",
-        "cj9s6y5g"
+        "cj9s6y5g", VARS_STD
     },
     /* Multi-path */
     {
@@ -1018,37 +1028,37 @@ static const struct descriptor_test {
         "pkh(mainnet_xpub/<0;1>)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
-        "uvzwp2pn"
+        "uvzwp2pn", VARS_STD
     }, {
         "descriptor - hardened multi-path",
         "pkh(mainnet_xpriv/<0';1>)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "76a91417bf6f67bef3cdea94ebf7dae2193e7d7d2c654588ac",
-        "e9pr7748"
+        "e9pr7748", VARS_STD
     }, {
         "descriptor - ranged multi-path",
         "pkh(mainnet_xpub/<0;1>/*)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "76a9143099ad49dfdd021bf3748f7f858e0d1fa0b4f6f888ac",
-        "ydnzkve4"
+        "ydnzkve4", VARS_STD
     },{
         "descriptor - variant ranged multi-path)",
         "combo(mainnet_xpub/<0;1>/*)",
         WALLY_NETWORK_NONE, 0, 0, 0, NULL, 0,
         "21038145454b87fc9ec3557478d6eadc2aea290b50f3c469b828abeb542ae8f8849dac",
-        "j7jej0ue"
+        "j7jej0ue", VARS_STD
     }, {
         "descriptor - multi-path and non-multi-path elements (1)",
         "multi(2,mainnet_xpub,mainnet_xpub/<0;1;2>)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "522102d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f021025d5fc65ebb8d44a5274b53bac21ff8307fec2334a32df05553459f8b1f7fe1b652ae",
-        "la88a48t"
+        "la88a48t", VARS_STD
     }, {
         "descriptor - multi-path and non-multi-path elements (2)",
         "multi(2,mainnet_xpub/<0;1;2>/*,mainnet_xpub)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "5221038145454b87fc9ec3557478d6eadc2aea290b50f3c469b828abeb542ae8f8849d2102d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f052ae",
-        "y5pky4r2"
+        "y5pky4r2", VARS_STD
     },
     /* Wallet policies https://github.com/bitcoin/bips/pull/1389 */
     {
@@ -1056,31 +1066,31 @@ static const struct descriptor_test {
         "pkh(mainnet_xpub/*)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0,
         "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
-        "cp8r8rlg"
+        "cp8r8rlg", VARS_STD
     }, {
         "policy - single asterisk",
         "pkh(@0/*)", // Becomes "pkh(mainnet_xpub/*)" i.e. the test case above this
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
         "76a914bb57ca9e62c7084081edc68d2cbc9524a523784288ac",
-        "cp8r8rlg"
+        "cp8r8rlg", VARS_P_1
     }, {
         "policy - double asterisk",
         "pkh(@0/**)", // Becomes "pkh(mainnet_xpub/<0;1>/*)"
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
         "76a9143099ad49dfdd021bf3748f7f858e0d1fa0b4f6f888ac",
-        "ydnzkve4"
+        "ydnzkve4", VARS_P_1
     }, {
         "policy - multi-path",
         "pkh(@0/<0;1>/*)", // Becomes "pkh(mainnet_xpub/<0;1>/*)"
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
         "76a9143099ad49dfdd021bf3748f7f858e0d1fa0b4f6f888ac",
-        "ydnzkve4"
+        "ydnzkve4", VARS_P_1
     }, {
         "policy - previous key reference",
         "sh(multi(1,@0/**,@1/**,@0/<2;3>/*))", /* For testing: expresssion isn't sensible */
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, WALLY_MINISCRIPT_POLICY_TEMPLATE,
         "a9146cc69bc5443e97b8a30918cb6297ba4efb3d6dc387",
-        "45w36ywr"
+        "45w36ywr", VARS_P_2
     },
     /*
      * Misc error cases (code coverage)
@@ -1088,350 +1098,350 @@ static const struct descriptor_test {
     {
         "descriptor errchk - invalid checksum",
         "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)#8rap84p2",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - missing required checksum",
         "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, WALLY_MINISCRIPT_REQUIRE_CHECKSUM,
         NULL,
-        ""
+        "", VARS_STD
     },{
         "descriptor errchk - hardened xpub", /* TODO: Allow setting an xpriv into the descriptor */
         "pkh(mainnet_xpub/1'/2)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - upper case hardened indicator",
         "pkh(mainnet_xpriv/1H/2)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - trailing path",
         "wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)/1/2",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - privkey - unmatch network1",
         "wpkh(cSMSHUGbEiZQUXVw9zA33yT3m8fgC27rn2XEGZJupwCpsRS3rAYa)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - privkey - unmatch network2",
         "wpkh(cSMSHUGbEiZQUXVw9zA33yT3m8fgC27rn2XEGZJupwCpsRS3rAYa)",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - privkey - unmatch network3",
         "wpkh(L4gLCkRn5VfJsDSWsrrC57kqVgq6Z2sjeRELmim5zzAgJisysh17)",
-        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - privkey - unmatch network4",
         "wpkh(L4gLCkRn5VfJsDSWsrrC57kqVgq6Z2sjeRELmim5zzAgJisysh17)",
-        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - privkey - unmatch network5",
         "wpkh(L4gLCkRn5VfJsDSWsrrC57kqVgq6Z2sjeRELmim5zzAgJisysh17)",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xpubkey - unmatch network1",
         "wpkh(testnet_xpub)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xpubkey - unmatch network2",
         "wpkh(testnet_xpub)",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xpubkey - unmatch network3",
         "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
-        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xpubkey - unmatch network4",
         "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
-        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xpubkey - unmatch network5",
         "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xprivkey - unmatch network1",
         "wpkh(tprv8jDG3g2yc8vh71x9ejCDSfMz4AuQRx7MMNBXXvpD4jh7CkDuB3ZmnLVcEM99jgg5MaSp7gYNpnKS5dvkGqq7ad8X63tE7yFaMGTfp6gD54p)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xprivkey - unmatch network2",
         "wpkh(tprv8jDG3g2yc8vh71x9ejCDSfMz4AuQRx7MMNBXXvpD4jh7CkDuB3ZmnLVcEM99jgg5MaSp7gYNpnKS5dvkGqq7ad8X63tE7yFaMGTfp6gD54p)",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xprivkey - unmatch network3",
         "wpkh(mainnet_xpriv)",
-        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xprivkey - unmatch network4",
         "wpkh(mainnet_xpriv)",
-        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - xprivkey - unmatch network5",
         "wpkh(mainnet_xpriv)",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - addr - empty addr",
         "addr()",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - addr - unmatch network1",
         "addr(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3)",
-        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - addr - unmatch network2",
         "addr(ex1qwu7hp9vckakyuw6htsy244qxtztrlyez4l7qlrpg68v6drgvj39q06fgz7)",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multisig too many keys",
         /*        1     2     3     4     5     6     7     8     9     10    11    12    13    14    15      16 */
         "sh(multi(1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1,key_1))",
-        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID_REGTEST, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sh - non-root",
         "sh(sh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sh - multi-child",
         "sh(sh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wsh - non-sh parent",
         "wsh(wsh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wsh uncompressed",
         "wsh(936Xapr4wpeuiKToGeXtEcsVJAfE6ze8KUEb2UQu72rzBQsMZdX)",
-        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_TESTNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wsh - multi-child",
         "wsh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - pk - non-key child",
         "pk(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - pk - invalid public key",
         "pk(uncompresseduncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - pk - x-only child",
         "pk(x_only)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - pk - multi-child",
         "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wpkh - multi-child",
         "wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556,03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wpkh - non-key child",
         "wpkh(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wpkh - wsh parent",
         "wsh(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wpkh - descriptor type parent",
         "pk(wpkh(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wpkh uncompressed",
         "wpkh(uncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sh(wpkh) uncompressed",
         "sh(wpkh(uncompressed))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - combo - any parent",
         "sh(combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - combo - multi-child",
         "combo(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - no args",
         "multi",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - no children",
         "multi()",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - not enough children",
         "multi(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - no number",
         "multi(022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - negative number",
         "multi(-1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - multi - non-key child",
         "multi(1,1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - no args",
         "sortedmulti",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - no children",
         "sortedmulti()",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - not enough children",
         "sortedmulti(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - no number",
         "sortedmulti(022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4,025cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - negative number",
         "sortedmulti(-1,022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sortedmulti - non-key child",
         "sortedmulti(1,1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - addr - multi-child",
         "addr(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3,bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - addr - non-address child",
         /* Note: The actual check in verify_addr is unreachable as children
          *       of addr() nodes are only analysed as addresses. */
         "addr(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - addr - any parent",
         "sh(addr(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - raw - multi-child",
         "raw(000102030405060708090a0b0c0d0e0f,000102030405060708090a0b0c0d0e0f)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - raw - non-raw child",
         /* Note: The actual check in verify_raw is unreachable as children
          *       of raw() nodes are only analysed as raw hex. */
         "raw(1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - raw - any parent",
         "sh(raw(000102030405060708090a0b0c0d0e0f))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - empty rawtr",
         "rawtr()",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - rawtr - multi-child",
         "rawtr(x_only,x_only)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - rawtr - any parent",
         "sh(rawtr(x_only))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - rawtr - uncompressed key",
         "rawtr(uncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - rawtr - explicit public key",
         "rawtr(pk(key_1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - rawtr - invalid public key",
         "rawtr(uncompresseduncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - empty tr",
         "tr()",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - tr - multi-child",
         "tr(x_only,x_only)", /* FIXME: delete this case when script path is supported */
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - tr - any parent",
         "sh(tr(x_only))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - tr - uncompressed key",
         "tr(uncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - tr - explicit public key",
         "tr(pk(key_1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - tr - invalid public key",
         "tr(uncompresseduncompressed)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - after - non number child",
         "wsh(after(key_1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - after - zero delay",
         "wsh(after(0))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - after - negative delay",
         "wsh(after(-1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - after - delay too large",
         "wsh(after(2147483648))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - older - non number child",
         "wsh(older(key_1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - older - zero delay",
         "wsh(older(0))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - older - negative delay",
         "wsh(older(-1))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - older - delay too large",
         "wsh(older(2147483648))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "miniscript - thresh - zero required",
         "wsh(thresh(0,c:pk_k(key_1),sc:pk_k(key_2),sc:pk_k(key_3)))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "miniscript - thresh - require more than available children",
         "wsh(thresh(4,c:pk_k(key_1),sc:pk_k(key_2),sc:pk_k(key_3)))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - wsh-pk uncompressed",
         "wsh(pk(uncompressed))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor - sh(wsh-pk) uncompressed",
         "sh(wsh(pk(uncompressed)))",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "miniscript - core recursion limit",
         "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },{
         "descriptor errchk - wrapper on non-miniscript element",
         "v:addr(moUfpGiXWcFd5ueRn3988VDqRSkB5NrEmW)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },
     /* https://github.com/rust-bitcoin/rust-miniscript/blob/master/src/descriptor/key.rs
      * (Adapted)
@@ -1439,232 +1449,232 @@ static const struct descriptor_test {
     {
         "miniscript - invalid xpub",
         "pk([78412e3a]xpub1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaLcgJvLJuZZvRcEL/1/1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - invalid raw key",
         "pk([78412e3a]0208a117f3897c3a13c9384b8695eed98dc31bc2500feb19a1af424cd47a5d83/1/1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - invalid fingerprint separator",
         "pk([78412e3a]]0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798/1/1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - fuzzer error (1)",
         "pk([11111f11]033333333333333333333333333333323333333333333333333333333433333333]]333]]3]]101333333333333433333]]]10]333333mmmm)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - fuzzer error (2)",
         "pk(0777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - Non-hex fingerprint",
         "pk([NonHexor]0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - Short fingerprint",
         "pk([1122334]",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "miniscript - Long fingerprint",
         "pk([112233445]",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },
     /* https://github.com/rust-bitcoin/rust-miniscript/blob/master/src/descriptor/mod.rs */
     {
         "descriptor - unclosed brace",
         "(",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - unclosed brace (nested)",
         "(x()",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - invalid char",
         "(\x7f()3",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - empty pk",
         "pk(]",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },
     /* TODO: Add more tests for verify_x cases */
     /* Multi-path error cases */
     {
         "descriptor - unterminated multi-path (1)",
         "pkh(mainnet_xpub/<)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - unterminated multi-path (2)",
         "pkh(mainnet_xpub/<0)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - unterminated multi-path (3)",
         "pkh(mainnet_xpub/<0;)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - unterminated multi-path (4)",
         "pkh(mainnet_xpub/<0;1)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path missing first child",
         "pkh(mainnet_xpub/<;1>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path missing final child",
         "pkh(mainnet_xpub/<0;1;>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path non-number child",
         "pkh(mainnet_xpub/<0;a>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path child separator",
         "pkh(mainnet_xpub/<0;/>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path whildcard (1)",
         "pkh(mainnet_xpub/<*;1>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - multi-path whildcard (2)",
         "pkh(mainnet_xpub/<0;*>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - not enough  multi-path elements",
         "pkh(mainnet_xpub/<0>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - Too many multi-path elements (>255)",
         "pkh(mainnet_xpub/<1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - mismatched multi-path element counts",
         "multi(2,mainnet_xpub/<0;1>,mainnet_xpub/<0;1;2>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor - hardened xpub multi-path", /* TODO: Allow setting an xpriv into the descriptor */
         "pkh(mainnet_xpub/<0';1>)",
-        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     },
     /* Wallet policy error cases */
     {
         "policy errchk - no key expression",
         "raw()",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - key with path",
         "pkh(@0/0/*)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - missing key postfix",
         "pkh(@0)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - terminal key postfix",
         "@0",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - missing key number",
         "@",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - mis-ordered keys",
         "sh(multi(1,@1/**,@0/**))",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_2
     }, {
         "policy errchk - non-policy keys",
         "sh(multi(1,@0/**,xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU))",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - mismatched key cardinalities (1)",
         "sh(multi(1,@0/**,@1/*))",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_2
     }, {
         "policy errchk - mismatched key cardinalities (2)",
         "sh(multi(1,@0/<0;1>/*,@1/*))",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_2
     }, {
         "policy errchk - invalid key cardinality (key path)",
         "pkh(@0/<0;1;2>/*)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }, {
         "policy errchk - invalid key cardinality (variant)",
         "combo(@0/**)",
         WALLY_NETWORK_BITCOIN_MAINNET, 0, 0, 0, NULL,
-        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, ""
+        WALLY_MINISCRIPT_POLICY_TEMPLATE, NULL, "", VARS_P_1
     }
 #ifdef BUILD_ELEMENTS
     /* Elements/Confidential descriptor error cases */
     , {
         "descriptor errchk - empty ct()",
         "ct()",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - wrapper on ct()",
         "v:ct(slip77(slip77_key),elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - single child ct()",
         "ct(slip77(slip77_key))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - multiple blinding keys in ct()",
         "ct(slip77(slip77_key),slip77(slip77_key))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - missing blinding key in ct()",
         "ct(elpkh(key_4),elpkh(mainnet_xpub))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - multiple descriptors in ct()",
         "ct(slip77(slip77_key),elpkh(key_4),elpkh(mainnet_xpub))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - no args to slip77()",
         "ct(slip77,elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - empty args to slip77()",
         "ct(slip77(),elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - invalid blinding key in slip77()",
         "ct(slip77(010101010101010101),elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - wrapper on slip77()",
         "ct(v:slip77(slip77_key),elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - ELIP 150 WIF private key",
         "ct(L3jXxwef3fpB7hcrFozcWgHeJCPSAFiZ1Ji2YJMPxceaGvy3PC1q,elwpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4))#gcy6hcfz",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - ELIP 150 blinding key with wildcard",
         "ct(mainnet_xpub/0/*,elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - ELIP 150 blinding key with multipath",
         "ct(mainnet_xpub/<0;1>,elpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - ELIP 150 short hex key",
         "ct(fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90,elwpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }, {
         "descriptor errchk - ELIP 150 long hex key",
         "ct(0202fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90,elwpkh(key_4))",
-        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, ""
+        WALLY_NETWORK_LIQUID, 0, 0, 0, NULL, 0, NULL, "", VARS_STD
     }
 #endif /* BUILD_ELEMENTS */
 };
@@ -2260,15 +2270,10 @@ static bool check_descriptor_to_script(const struct descriptor_test* test)
     uint32_t multi_index = 0;
     uint32_t child_num = test->child_num ? *test->child_num : 0, features;
     const bool is_policy = test->flags & WALLY_MINISCRIPT_POLICY_TEMPLATE;
-    const struct wally_map *keys = is_policy ? &g_policy_maps[0] : &g_key_map;
+    const struct wally_map *keys = &g_policy_maps[test->policy_map_index];
 
-    /* Parse the descriptor. For policy tests, use the policy keys */
+    /* Parse the descriptor. */
     expected_ret = test->script ? WALLY_OK : WALLY_EINVAL;
-    if (is_policy && expected_ret == WALLY_OK) {
-        const char *p = strchr(test->descriptor, '@');
-        if (p && strchr(p + 1, '@'))
-            keys = &g_policy_maps[1]; /* 2-Element policy key map */
-    }
     ret = wally_descriptor_parse(test->descriptor, keys, test->network,
                                  test->flags, &descriptor);
     if (is_policy && expected_ret == WALLY_OK) {

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -310,7 +310,12 @@ static bool strtoll_n(const char *str, size_t str_len, int64_t *v)
     char *end = NULL;
 
     if (!str_len || str_len > sizeof(buf) - 1u ||
-        (str[0] != '-' && (str[0] < '0' || str[0] > '9')))
+        /* Must start with '-' or a number */
+        (str[0] != '-' && (str[0] < '0' || str[0] > '9')) ||
+        /* Must not contain leading zeros */
+        (str[0] == '0' && str_len > 1) ||
+        /* Must not be negative and contain leading zeros */
+        (str[0] == '-' && str_len > 1 && str[1] == '0'))
         return false; /* Too short/long, or invalid format */
 
     memcpy(buf, str, str_len);
@@ -2893,9 +2898,10 @@ static bool is_valid_policy_map(const struct wally_map *map_in)
     for (i = 0; ret == WALLY_OK && i < map_in->num_items; ++i) {
         const struct wally_map_item *item = &map_in->items[i];
         if (!item->key || item->key_len < 2 || item->key[0] != '@' ||
-            !strtoll_n((const char *)item->key + 1, item->key_len - 1, &v) || v < 0)
-            ret = WALLY_EINVAL; /* Policy keys can only be @n */
-        else if ((size_t)v != i)
+            !strtoll_n((const char *)item->key + 1, item->key_len - 1, &v) || v < 0) {
+            /* Policy keys can only be @n: positive integers */
+            ret = WALLY_EINVAL;
+        } else if ((size_t)v != i)
             ret = WALLY_EINVAL; /* Must be sorted in order from 0-n */
         else if (!item->value || !item->value_len)
             ret = WALLY_EINVAL; /* No key value */

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -301,7 +301,14 @@ static const struct addr_ver_t *addr_ver_from_family(
 static const struct ms_builtin_t *builtin_get(const ms_node *node);
 static int generate_script(ms_ctx *ctx, ms_node *node,
                            unsigned char *script, size_t script_len, size_t *written);
-static bool is_valid_policy_map(const struct wally_map *map_in);
+static int is_valid_policy_map(const struct wally_map *map_in, bool *is_elements);
+
+static bool is_elements_policy_map(const struct wally_map *map_in)
+{
+    /* Elements policy maps must have the blinding key @B first */
+    return map_in->num_items && map_in->items[0].key_len == 2 &&
+        map_in->items[0].key[0] == '@' && map_in->items[0].key[1] == 'B';
+}
 
 /* Wrapper for strtoll */
 static bool strtoll_n(const char *str, size_t str_len, int64_t *v)
@@ -399,7 +406,8 @@ static bool is_identifer_char(char c)
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
 }
 static bool is_policy_start_char(char c) { return c == '@'; }
-static bool is_policy_identifer_char(char c) { return c >= '0' && c <= '9'; }
+static bool is_policy_id_char(char c) { return c >= '0' && c <= '9'; }
+static bool is_elements_policy_id_char(char c) { return c == 'B' || is_policy_id_char(c); }
 
 static int canonicalize_impl(const char *descriptor,
                              const struct wally_map *vars_in, uint32_t flags,
@@ -411,7 +419,8 @@ static int canonicalize_impl(const char *descriptor,
     int key_index_hwm = -1;
     const char *p = descriptor, *start;
     char *out;
-    bool found_policy_single = false, found_policy_multi = false;;
+    bool found_policy_single = false, found_policy_multi = false;
+    bool found_policy_elements = false;
 
     *output = NULL;
     *num_substitutions = 0;
@@ -419,10 +428,15 @@ static int canonicalize_impl(const char *descriptor,
         return WALLY_EINVAL;
 
     if (flags & WALLY_MINISCRIPT_POLICY_TEMPLATE) {
-        if (!is_valid_policy_map(vars_in))
-            return WALLY_EINVAL; /* Invalid policy variables given */
+        const int ret = is_valid_policy_map(vars_in, &found_policy_elements);
+        if (ret != WALLY_OK)
+            return ret; /* Invalid policy variables given */
+#ifndef BUILD_ELEMENTS
+        if (found_policy_elements)
+            return WALLY_EINVAL; /* No Elements support */
+#endif
         is_id_start = is_policy_start_char;
-        is_id_char = is_policy_identifer_char;
+        is_id_char = found_policy_elements ? is_elements_policy_id_char : is_policy_id_char;
     }
 
     /* First, find the length of the canonicalized descriptor */
@@ -457,6 +471,17 @@ static int canonicalize_impl(const char *descriptor,
                         return WALLY_EINVAL; /* Must be ordered with no gaps */
                     if (key_index > key_index_hwm)
                         key_index_hwm = key_index;
+                    if (found_policy_elements && key_index == 0) {
+                        /* The blinding key in a ct() policy */
+                        if (*p != ')' && *p != ',')
+                            return WALLY_EINVAL; /* Must be a single key */
+                        continue;
+                    }
+                    /* Check for a key path. Note that policies, unlike
+                     * raw descriptors, cannot be used to encode single
+                     * keys (as they are used to register wallet structures,
+                     * not to expose single addresses).
+                     */
                     if (*p++ != '/')
                         return WALLY_EINVAL;
                     ++required_len;
@@ -2331,7 +2356,7 @@ static int analyze_key_hex(ms_ctx *ctx, ms_node *node,
 }
 
 static int analyze_miniscript_key(ms_ctx *ctx, uint32_t flags,
-                                  ms_node *node, ms_node *parent)
+                                  ms_node *node, ms_node *parent, bool force_ct)
 {
     unsigned char privkey[2 + EC_PRIVATE_KEY_LEN + BASE58_CHECKSUM_LEN];
     struct ext_key extkey;
@@ -2340,10 +2365,11 @@ static int analyze_miniscript_key(ms_ctx *ctx, uint32_t flags,
     bool is_hex;
 #ifdef BUILD_ELEMENTS
     /* Whether we are the blinding key child of a ct() expression */
-    const bool is_ct_key = parent && parent->kind == KIND_DESCRIPTOR_CT &&
-        !parent->child; /* If no child, we are the first child */
+    const bool is_ct_key = force_ct || (parent && parent->kind == KIND_DESCRIPTOR_CT &&
+        !parent->child); /* If no child, we are the first child */
 #else
     const bool is_ct_key = false;
+    (void)force_ct;
 #endif
 
     if (!node || (parent && !parent->builtin))
@@ -2546,7 +2572,8 @@ static int analyze_miniscript_value(ms_ctx *ctx, const char *str, size_t str_len
         node->kind = KIND_NUMBER;
         return WALLY_OK;
     }
-    return analyze_miniscript_key(ctx, flags, node, parent);
+    const bool force_ct = false;
+    return analyze_miniscript_key(ctx, flags, node, parent, force_ct);
 }
 
 static int analyze_miniscript(ms_ctx *ctx, const char *str, size_t str_len,
@@ -2880,7 +2907,7 @@ static uint32_t get_max_depth(const char *miniscript, size_t miniscript_len)
     return depth == 1 ? max_depth : 0xffffffff;
 }
 
-static bool is_valid_policy_map(const struct wally_map *map_in)
+static int is_valid_policy_map(const struct wally_map *map_in, bool *is_elements)
 {
     struct wally_map keys;
     ms_ctx ctx;
@@ -2888,6 +2915,8 @@ static bool is_valid_policy_map(const struct wally_map *map_in)
     int64_t v;
     size_t i;
     int ret = WALLY_OK;
+
+    *is_elements = false;
 
     if (!map_in || !map_in->num_items)
         return WALLY_EINVAL; /* Must contain at least one key expression */
@@ -2898,37 +2927,56 @@ static bool is_valid_policy_map(const struct wally_map *map_in)
     for (i = 0; ret == WALLY_OK && i < map_in->num_items; ++i) {
         const struct wally_map_item *item = &map_in->items[i];
         if (!item->key || item->key_len < 2 || item->key[0] != '@' ||
-            !strtoll_n((const char *)item->key + 1, item->key_len - 1, &v) || v < 0) {
-            /* Policy keys can only be @n: positive integers */
-            ret = WALLY_EINVAL;
-        } else if ((size_t)v != i)
-            ret = WALLY_EINVAL; /* Must be sorted in order from 0-n */
-        else if (!item->value || !item->value_len)
-            ret = WALLY_EINVAL; /* No key value */
-        else if (!(node = wally_calloc(sizeof(*node))))
+            !item->value || !item->value_len)
+            goto fail; /* No valid key/value */
+
+        if (i == 0 && item->key_len == 2 && item->key[1] == 'B') {
+            /* @B can be used as the first (blinding) key for ct() policies */
+            *is_elements = true;
+        } else {
+            /* Policy keys can only be @n: positive integers,
+               and must be sorted in order from 0-n */
+            if (!strtoll_n((const char *)item->key + 1, item->key_len - 1, &v) ||
+                v < 0 || (size_t)v + (*is_elements ? 1 : 0) != i)
+                goto fail;
+        }
+
+        if (!(node = wally_calloc(sizeof(*node)))) {
             ret = WALLY_ENOMEM;
-        else {
-            node->data = (const char*)item->value;
-            node->data_len = item->value_len;
-            if (analyze_miniscript_key(&ctx, 0, node, NULL) != WALLY_OK ||
-                node->kind != KIND_BIP32_PUBLIC_KEY ||
-                node->child_path_len) {
+            goto fail_nomem;
+        }
+
+        /* Parse the key data */
+        node->data = (const char*)item->value;
+        node->data_len = item->value_len;
+        const bool force_ct = *is_elements && i == 0;
+        ret = analyze_miniscript_key(&ctx, 0, node, NULL, force_ct);
+        if (ret == WALLY_OK) {
+            if (force_ct && node->kind == KIND_PRIVATE_KEY) {
+                /* Valid 64 byte hex blinding key: */
+                /* no-op */;
+            } else if (node->kind != KIND_BIP32_PUBLIC_KEY || node->child_path_len) {
                 ret = WALLY_EINVAL; /* Only BIP32 xpubs are allowed */
-            } else if (ctx.features & (WALLY_MS_IS_MULTIPATH | WALLY_MS_IS_RANGED)) {
+            }
+            if (ctx.features & (WALLY_MS_IS_MULTIPATH | WALLY_MS_IS_RANGED)) {
                 /* Range or multipath must be part of the expression, not the key */
                 ret = WALLY_EINVAL;
-            } else {
+            } else if (ret == WALLY_OK) {
                 ret = wally_map_add(&keys, item->value, item->value_len, NULL, 0);
             }
-            node_free(node);
         }
+        node_free(node);
     }
-    if (ret == WALLY_OK && keys.num_items != map_in->num_items)
-        ret = WALLY_EINVAL; /* One of more keys is not unique */
+    if (ret == WALLY_OK && keys.num_items != map_in->num_items) {
+        /* One of more keys is not unique */
+fail:
+        ret = WALLY_EINVAL;
+    }
+fail_nomem:
     clear_and_free(ctx.keys.items,
                    ctx.keys.num_items * sizeof(*ctx.keys.items));
     wally_map_clear(&keys);
-    return ret == WALLY_OK;
+    return ret;
 }
 
 int wally_descriptor_parse(const char *miniscript,
@@ -2966,6 +3014,10 @@ int wally_descriptor_parse(const char *miniscript,
     if (ret == WALLY_OK)
         ret = canonicalize_impl(miniscript, vars_in, flags & MS_FLAGS_CANONICALIZE,
                                 &ctx->src, &num_substitutions);
+    if (ret == WALLY_OK && (flags & WALLY_MINISCRIPT_POLICY_TEMPLATE)) {
+        if (!num_substitutions)
+            ret = WALLY_EINVAL; /* Policy with no keys substituted */
+    }
     if (ret == WALLY_OK) {
         ctx->src_len = strlen(ctx->src);
         ctx->features = WALLY_MS_IS_DESCRIPTOR; /* Un-set if miniscript found */
@@ -2981,12 +3033,17 @@ int wally_descriptor_parse(const char *miniscript,
         if (ret == WALLY_OK)
             ret = node_generation_size(ctx->top_node, &ctx->script_len);
         if (ret == WALLY_OK && (flags & WALLY_MINISCRIPT_POLICY_TEMPLATE)) {
-            if (ctx->keys.num_items != num_substitutions)
+            const bool have_blinding_key = is_elements_policy_map(vars_in);
+            const size_t num_skipped_keys = have_blinding_key ? 1 : 0;
+            if (ctx->keys.num_items != num_substitutions - num_skipped_keys)
                 ret = WALLY_EINVAL; /* non-substituted key in the expression */
-            else if (vars_in && ctx->keys.num_items < vars_in->num_items)
+            else if (vars_in && ctx->keys.num_items + num_skipped_keys < vars_in->num_items)
                 ret = WALLY_EINVAL; /* non-substituted key in substitutions */
             else if (ctx->num_variants > 1 || ctx->num_multipaths > 2)
                 ret = WALLY_EINVAL; /* Solved cardinality must be 1 or 2 */
+            else if ((ctx->features & (WALLY_MS_IS_SLIP77 | WALLY_MS_IS_ELIP150)) &&
+                    !have_blinding_key)
+                ret = WALLY_EINVAL; /* this ct policy requires a blinding key var */
             else if (flags & WALLY_MINISCRIPT_UNIQUE_KEYPATHS)
                 ret = ensure_unique_policy_keys(ctx);
         }

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -2906,7 +2906,7 @@ static bool is_valid_policy_map(const struct wally_map *map_in)
         else if (!item->value || !item->value_len)
             ret = WALLY_EINVAL; /* No key value */
         else if (!(node = wally_calloc(sizeof(*node))))
-            ret = WALLY_EINVAL;
+            ret = WALLY_ENOMEM;
         else {
             node->data = (const char*)item->value;
             node->data_len = item->value_len;

--- a/src/test/test_descriptor.py
+++ b/src/test/test_descriptor.py
@@ -338,6 +338,7 @@ class DescriptorTests(unittest.TestCase):
     def test_policy(self):
         """Test policy parsing"""
         # Substitution variables
+        slip77 = 'b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04'
         xpriv = 'xprvA2YKGLieCs6cWCiczALiH1jzk3VCCS5M1pGQfWPkamCdR9UpBgE2Gb8AKAyVjKHkz8v37avcfRjdcnP19dVAmZrvZQfvTcXXSAiFNQ6tTtU'
         xpub1 = 'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL'
         xpub2 = 'xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU'
@@ -384,6 +385,33 @@ class DescriptorTests(unittest.TestCase):
             ret = wally_descriptor_parse(policy, keys, NETWORK_BTC_MAIN, flags, d)
             self.assertEqual(ret, WALLY_EINVAL)
             wally_map_free(keys)
+
+        # Elements confidential policy parsing"""
+        if not wally_is_elements_build()[1]:
+            return  # Not enabled
+
+        P = POLICY
+        cases = [
+            # slip77 with a 64 byte hex slip77 blinding key
+            [P, 'ct(slip77(@B),elpkh(@0/*))', {'@B': slip77, '@0': xpub1}],
+            # elip150 with a 64 byte hex private blinding key
+            [P, 'ct(@B,elpkh(@0/*))',         {'@B': slip77, '@0': xpub1}],
+            # elip150 with an xpub blinding key
+            [P, 'ct(@B,elpkh(@0/*))',         {'@B': xpub1,  '@0': xpub2}],
+        ]
+        d = c_void_p()
+        for flags, policy, key_items in cases:
+            keys = wally_map_from_dict(key_items)
+            ret = wally_descriptor_parse(policy, keys, NETWORK_LIQUID, flags, d)
+            self.assertEqual(ret, WALLY_OK)
+            ret, num_keys = wally_descriptor_get_num_keys(d)
+            self.assertEqual((ret, num_keys), (WALLY_OK, 1)) # Only non-blinding
+            ret, key_str = wally_descriptor_get_key(d, 0)
+            self.assertEqual((ret, key_str), (WALLY_OK, key_items['@0']))
+            ret, key_info = wally_descriptor_get_key(d, BLINDING_KEY_INDEX)
+            self.assertEqual((ret, key_info), (WALLY_OK, key_items['@B']))
+            wally_map_free(keys)
+            wally_descriptor_free(d)
 
     def test_key_iteration(self):
         """Test iterating descriptor keys"""

--- a/src/test/test_descriptor.py
+++ b/src/test/test_descriptor.py
@@ -370,6 +370,13 @@ class DescriptorTests(unittest.TestCase):
             # Key multi-paths must be disjoint sets
             [P|K, 'sh(multi(1,@0/<0;1>/*,@0/<1;2>/*))', [xpub1]],
             [P|K, 'sh(multi(1,@0/<1;0>/*,@0/<2;1>/*))', [xpub1]],
+            # Keys must not be negative
+            [P, 'pkh(@-1/*)', {'@-1': xpub1}],
+            # Keys must not have leading space
+            [P, 'pkh(@ 0/*)', {'@ 0': xpub1}],
+            # Keys must not have leading zeros
+            [P, 'pkh(@00/*)', {'@00': xpub1}],
+            [P, 'sh(multi(1,@0/*,@01/*))', {'@0': xpub1, '@01': xpub2}],
         ]
         d = c_void_p()
         for flags, policy, key_items in bad_args:


### PR DESCRIPTION
```    
    These are the same as existing wallet policies except that the blinding
    key placeholder must be '@B`, which must be given first in the policy
    key map when parsing.
    
    This allows the blinding scheme and key to be presented separately from
    the rest of the policy which will then be identical (modulo el-prefixes)
    between elements and bitcoin for the same wallet structure.
    
    This also allows the distinction between blinding keys and policy keys
    to remain intact. Blinding keys are qualitatively different from
    derivation keys; they may for example be a real pubkey, raw entropy,
    and/or/in addition to an algorithm that operates on the result of the
    policy for given derivation indices (in the case of deterministic
    blinding). For these reasons blinding keys remain outside standard key
    iteration in a parsed descriptor.
```